### PR TITLE
refactor(layouts): Refactor spacing options into a dedicated service

### DIFF
--- a/kingly_layouts.services.yml
+++ b/kingly_layouts.services.yml
@@ -1,0 +1,4 @@
+services:
+  kingly_layouts.spacing:
+    class: Drupal\kingly_layouts\Service\SpacingService
+    arguments: [ '@current_user', '@string_translation' ]

--- a/src/KinglyLayoutsDisplayOptionInterface.php
+++ b/src/KinglyLayoutsDisplayOptionInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\kingly_layouts;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines an interface for Kingly Layouts display option services.
+ *
+ * Each service handles a specific category of layout settings, like Spacing,
+ * Borders, etc. It is responsible for building the configuration form elements,
+ * handling the form submission, and processing the build array to add classes
+ * and styles.
+ */
+interface KinglyLayoutsDisplayOptionInterface {
+
+  /**
+   * Builds the form elements for this display option category.
+   *
+   * @param array $form
+   *   The form array to which the elements will be added.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array $configuration
+   *   The layout's current configuration.
+   *
+   * @return array
+   *   The updated form array.
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array;
+
+  /**
+   * Handles the submission of the configuration form for this category.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array &$configuration
+   *   The layout's configuration array, passed by reference.
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void;
+
+  /**
+   * Processes the layout's build array to add classes, styles, or other data.
+   *
+   * @param array &$build
+   *   The render array for the layout, passed by reference.
+   * @param array $configuration
+   *   The layout's current configuration.
+   */
+  public function processBuild(array &$build, array $configuration): void;
+
+  /**
+   * Provides the default configuration values for this display option.
+   *
+   * @return array
+   *   An associative array of default configuration values.
+   */
+  public function defaultConfiguration(): array;
+
+}

--- a/src/KinglyLayoutsUtilityTrait.php
+++ b/src/KinglyLayoutsUtilityTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\kingly_layouts;
+
+/**
+ * Provides utility methods for Kingly Layouts services and plugins.
+ */
+trait KinglyLayoutsUtilityTrait {
+
+  /**
+   * Helper to apply a CSS class from a configuration value.
+   *
+   * The suffix for the class is determined by the value of the configuration
+   * key provided. This method can also accept a direct string value instead of
+   * a configuration key.
+   *
+   * @param array &$build
+   *   The render array.
+   * @param string $class_prefix
+   *   The prefix for the CSS class (e.g., 'kingly-layout-padding-x-').
+   * @param string $config_key_or_value
+   *   The configuration key (e.g., 'horizontal_padding_option') or a direct
+   *   string value (e.g., 'sm') to use for the class suffix.
+   * @param array $configuration
+   *   The layout's current configuration.
+   */
+  private function applyClassFromConfig(array &$build, string $class_prefix, string $config_key_or_value, array $configuration): void {
+    // Check if the provided string is a config key or a direct value.
+    $value = $configuration[$config_key_or_value] ?? $config_key_or_value;
+    if (!empty($value) && $value !== '_none') {
+      $build['#attributes']['class'][] = $class_prefix . $value;
+    }
+  }
+
+}

--- a/src/Service/SpacingService.php
+++ b/src/Service/SpacingService.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+
+/**
+ * Service to manage spacing options for Kingly Layouts.
+ */
+class SpacingService implements SpacingServiceInterface {
+
+  use StringTranslationTrait;
+  use KinglyLayoutsUtilityTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * Constructs a new SpacingService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['spacing'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Spacing'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts spacing'),
+    ];
+
+    $form['spacing']['horizontal_padding_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Horizontal Padding'),
+      '#options' => $this->getScaleOptions(),
+      '#default_value' => $configuration['horizontal_padding_option'],
+      '#description' => $this->t('Select the horizontal padding for the layout. For "Full Width (Background Only)" layouts, this padding is added to the default content alignment. For "Edge to Edge" layouts, this padding is applied from the viewport edge.'),
+    ];
+
+    $form['spacing']['vertical_padding_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Vertical Padding'),
+      '#options' => $this->getScaleOptions(),
+      '#default_value' => $configuration['vertical_padding_option'],
+      '#description' => $this->t('Select the desired vertical padding (top and bottom) for the layout container.'),
+    ];
+
+    $form['spacing']['gap_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Gap'),
+      '#options' => $this->getScaleOptions(),
+      '#default_value' => $configuration['gap_option'],
+      '#description' => $this->t('Select the desired gap between layout columns/regions.'),
+    ];
+
+    $form['spacing']['horizontal_margin_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Horizontal Margin'),
+      '#options' => $this->getScaleOptions(),
+      '#default_value' => $configuration['horizontal_margin_option'],
+      '#description' => $this->t('Select the horizontal margin for the layout. This margin will not be applied if "Full Width" or "Edge to Edge" is selected.'),
+    ];
+
+    $form['spacing']['vertical_margin_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Vertical Margin'),
+      '#options' => $this->getScaleOptions(),
+      '#default_value' => $configuration['vertical_margin_option'],
+      '#description' => $this->t('Select the desired vertical margin (top and bottom) for the layout container.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Returns the available padding scale options.
+   *
+   * @return array
+   *   An associative array of padding scale options.
+   */
+  protected function getScaleOptions(): array {
+    return [
+      self::NONE_OPTION_KEY => $this->t('None'),
+      'xs' => $this->t('Extra Small (0.25rem)'),
+      'sm' => $this->t('Small (0.5rem)'),
+      'md' => $this->t('Medium (1rem)'),
+      'lg' => $this->t('Large (2rem)'),
+      'xl' => $this->t('Extra Large (4rem)'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $spacing_values = $form_state->getValue('spacing', []);
+    foreach ([
+      'horizontal_padding_option',
+      'vertical_padding_option',
+      'gap_option',
+      'horizontal_margin_option',
+      'vertical_margin_option',
+    ] as $key) {
+      $configuration[$key] = $spacing_values[$key] ?? $this->defaultConfiguration()[$key];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    $padding_options = $this->getScaleOptions();
+    $default_padding = key($padding_options);
+
+    return [
+      'horizontal_padding_option' => $default_padding,
+      'vertical_padding_option' => $default_padding,
+      'gap_option' => key($this->getScaleOptions()),
+      'horizontal_margin_option' => self::NONE_OPTION_KEY,
+      'vertical_margin_option' => self::NONE_OPTION_KEY,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    // Determine effective padding and margin based on container type.
+    $container_type = $configuration['container_type'];
+    $h_padding_effective = $configuration['horizontal_padding_option'];
+    $apply_horizontal_margin = TRUE;
+
+    switch ($container_type) {
+      case 'full':
+        $apply_horizontal_margin = FALSE;
+        break;
+
+      case 'edge-to-edge':
+      case 'hero':
+        $h_padding_effective = self::NONE_OPTION_KEY;
+        $apply_horizontal_margin = FALSE;
+        break;
+    }
+
+    // Apply spacing utility classes.
+    $this->applyClassFromConfig($build, 'kingly-layout-padding-x-', $h_padding_effective, $configuration);
+    $this->applyClassFromConfig($build, 'kingly-layout-padding-y-', 'vertical_padding_option', $configuration);
+    $this->applyClassFromConfig($build, 'kingly-layout-gap-', 'gap_option', $configuration);
+    $this->applyClassFromConfig($build, 'kingly-layout-margin-y-', 'vertical_margin_option', $configuration);
+
+    if ($apply_horizontal_margin) {
+      $this->applyClassFromConfig($build, 'kingly-layout-margin-x-', 'horizontal_margin_option', $configuration);
+    }
+  }
+
+}

--- a/src/Service/SpacingServiceInterface.php
+++ b/src/Service/SpacingServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Interface for the Spacing service.
+ *
+ * Defines the contract for handling spacing-related layout options.
+ */
+interface SpacingServiceInterface extends KinglyLayoutsDisplayOptionInterface {
+
+  // Currently, no additional methods are needed beyond the base interface.
+  // This interface is created for type-hinting and future extensibility.
+}


### PR DESCRIPTION
This commit extracts all spacing-related logic (padding, margin, gap) from the monolithic `KinglyLayoutBase` class into a new, dedicated `SpacingService`.

This refactoring was done to:
- Improve code organization and maintainability by following the Single Responsibility Principle.
- Decouple layout options from the base layout plugin, making the system more modular and testable.
- Establish a clear pattern for adding future option groups (e.g., Borders, Backgrounds) as services.
- Simplify the `KinglyLayoutBase` class, making it easier to understand and extend.

Changes include:
- Creation of `SpacingService` to handle form building, submission, default configuration, and render processing for spacing.
- Introduction of `KinglyLayoutsDisplayOptionInterface` and `SpacingServiceInterface` to define a clear contract for this pattern.
- Addition of `KinglyLayoutsUtilityTrait` to share helper methods across services and plugins.
- `KinglyLayoutBase` is updated to inject and delegate all spacing-related tasks to the new service.