### PR TITLE
refactor(layout): Externalise layout settings into tagged services

### DIFF
--- a/kingly_layouts.services.yml
+++ b/kingly_layouts.services.yml
@@ -1,7 +1,57 @@
 services:
+  kingly_layouts.options:
+    class: Drupal\kingly_layouts\Service\OptionsService
+    arguments: ['@entity_type.manager', '@cache.default', '@string_translation']
   kingly_layouts.spacing:
     class: Drupal\kingly_layouts\Service\SpacingService
-    arguments: [ '@current_user', '@string_translation' ]
+    arguments: ['@current_user', '@string_translation']
+    tags:
+      - { name: kingly_layouts.display_option }
   kingly_layouts.alignment:
     class: Drupal\kingly_layouts\Service\AlignmentService
-    arguments: [ '@current_user', '@string_translation' ]
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.color:
+    class: Drupal\kingly_layouts\Service\ColorService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options', '@entity_type.manager']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.border:
+    class: Drupal\kingly_layouts\Service\BorderService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options', '@kingly_layouts.color']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.animation:
+    class: Drupal\kingly_layouts\Service\AnimationService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.background:
+    class: Drupal\kingly_layouts\Service\BackgroundService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options', '@kingly_layouts.color']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.shadows_effects:
+    class: Drupal\kingly_layouts\Service\ShadowsEffectsService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.responsiveness:
+    class: Drupal\kingly_layouts\Service\ResponsivenessService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.custom_attributes:
+    class: Drupal\kingly_layouts\Service\CustomAttributesService
+    arguments: ['@current_user', '@string_translation']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.container_type:
+    class: Drupal\kingly_layouts\Service\ContainerTypeService
+    arguments: ['@current_user', '@string_translation', '@kingly_layouts.options']
+    tags:
+      - { name: kingly_layouts.display_option }
+  kingly_layouts.display_option_manager:
+    class: Drupal\kingly_layouts\Service\DisplayOptionManager
+    arguments: ['@container.namespaces', '@cache.default', '@module_handler']

--- a/src/Hook/KinglyLayoutsHooks.php
+++ b/src/Hook/KinglyLayoutsHooks.php
@@ -10,7 +10,7 @@ use Drupal\Core\Hook\Attribute\Hook;
 class KinglyLayoutsHooks {
 
   /**
-   * {@inheritdoc}
+   * Implements hook_theme().
    */
   #[Hook('theme')]
   public function theme(): array {

--- a/src/KinglyLayoutsDisplayOptionInterface.php
+++ b/src/KinglyLayoutsDisplayOptionInterface.php
@@ -54,9 +54,12 @@ interface KinglyLayoutsDisplayOptionInterface {
   /**
    * Provides the default configuration values for this display option.
    *
+   * This method must be static as it can be called before the plugin or
+   * service is fully instantiated.
+   *
    * @return array
    *   An associative array of default configuration values.
    */
-  public function defaultConfiguration(): array;
+  public static function defaultConfiguration(): array;
 
 }

--- a/src/Plugin/Layout/KinglyLayoutBase.php
+++ b/src/Plugin/Layout/KinglyLayoutBase.php
@@ -2,16 +2,21 @@
 
 namespace Drupal\kingly_layouts\Plugin\Layout;
 
-use Drupal\Core\Cache\CacheBackendInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Layout\LayoutDefault;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
-use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
-use Drupal\taxonomy\TermInterface;
+use Drupal\kingly_layouts\Service\AlignmentService;
+use Drupal\kingly_layouts\Service\AnimationService;
+use Drupal\kingly_layouts\Service\BackgroundService;
+use Drupal\kingly_layouts\Service\BorderService;
+use Drupal\kingly_layouts\Service\ColorService;
+use Drupal\kingly_layouts\Service\ContainerTypeService;
+use Drupal\kingly_layouts\Service\CustomAttributesService;
+use Drupal\kingly_layouts\Service\ResponsivenessService;
+use Drupal\kingly_layouts\Service\ShadowsEffectsService;
+use Drupal\kingly_layouts\Service\SpacingService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -19,54 +24,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInterface, ContainerFactoryPluginInterface {
 
-  use KinglyLayoutsUtilityTrait;
-
-  /**
-   * The key used for the "None" option in select lists.
-   */
-  protected const NONE_OPTION_KEY = '_none';
-
-  /**
-   * The ID of the taxonomy vocabulary used for CSS colors.
-   */
-  protected const KINGLY_CSS_COLOR_VOCABULARY = 'kingly_css_color';
-
-  /**
-   * The field name on the taxonomy term that stores the hex color value.
-   */
-  protected const KINGLY_CSS_COLOR_FIELD = 'field_kingly_css_color';
-
-  /**
-   * The entity type manager.
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The term storage.
-   *
-   * @var \Drupal\taxonomy\TermStorageInterface
-   */
-  protected $termStorage;
-
-  /**
-   * The cache backend.
-   */
-  protected CacheBackendInterface $cache;
-
   /**
    * The current user.
    */
   protected AccountInterface $currentUser;
 
   /**
-   * The Kingly Layouts spacing service.
+   * An array of all display option services.
+   *
+   * @var \Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface[]
    */
-  protected KinglyLayoutsDisplayOptionInterface $spacingService;
-
-  /**
-   * The Kingly Layouts alignment service.
-   */
-  protected KinglyLayoutsDisplayOptionInterface $alignmentService;
+  protected array $displayOptionServices;
 
   /**
    * Constructs a new KinglyLayoutBase object.
@@ -77,25 +45,46 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
-   * @param \Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface $spacing_service
-   *   The Kingly Layouts spacing service.
-   * @param \Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface $alignment_service
-   *   The Kingly Layouts alignment service.
+   * @param \Drupal\kingly_layouts\Service\ContainerTypeService $container_type_service
+   *   The container type service.
+   * @param \Drupal\kingly_layouts\Service\SpacingService $spacing_service
+   *   The spacing service.
+   * @param \Drupal\kingly_layouts\Service\AlignmentService $alignment_service
+   *   The alignment service.
+   * @param \Drupal\kingly_layouts\Service\ColorService $color_service
+   *   The color service.
+   * @param \Drupal\kingly_layouts\Service\BorderService $border_service
+   *   The border service.
+   * @param \Drupal\kingly_layouts\Service\AnimationService $animation_service
+   *   The animation service.
+   * @param \Drupal\kingly_layouts\Service\BackgroundService $background_service
+   *   The background service.
+   * @param \Drupal\kingly_layouts\Service\ShadowsEffectsService $shadows_effects_service
+   *   The shadows and effects service.
+   * @param \Drupal\kingly_layouts\Service\ResponsivenessService $responsiveness_service
+   *   The responsiveness service.
+   * @param \Drupal\kingly_layouts\Service\CustomAttributesService $custom_attributes_service
+   *   The custom attributes service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache_backend, AccountInterface $current_user, KinglyLayoutsDisplayOptionInterface $spacing_service, KinglyLayoutsDisplayOptionInterface $alignment_service) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AccountInterface $current_user, ContainerTypeService $container_type_service, SpacingService $spacing_service, AlignmentService $alignment_service, ColorService $color_service, BorderService $border_service, AnimationService $animation_service, BackgroundService $background_service, ShadowsEffectsService $shadows_effects_service, ResponsivenessService $responsiveness_service, CustomAttributesService $custom_attributes_service) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
-    $this->cache = $cache_backend;
     $this->currentUser = $current_user;
-    $this->spacingService = $spacing_service;
-    $this->alignmentService = $alignment_service;
+
+    // Assign all the display option services in a consistent order.
+    $this->displayOptionServices = [
+      'container_type' => $container_type_service,
+      'spacing' => $spacing_service,
+      'colors' => $color_service,
+      'border' => $border_service,
+      'alignment' => $alignment_service,
+      'animation' => $animation_service,
+      'background' => $background_service,
+      'shadows_effects' => $shadows_effects_service,
+      'responsiveness' => $responsiveness_service,
+      'custom_attributes' => $custom_attributes_service,
+    ];
   }
 
   /**
@@ -106,11 +95,17 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('cache.default'),
       $container->get('current_user'),
+      $container->get('kingly_layouts.container_type'),
       $container->get('kingly_layouts.spacing'),
-      $container->get('kingly_layouts.alignment')
+      $container->get('kingly_layouts.alignment'),
+      $container->get('kingly_layouts.color'),
+      $container->get('kingly_layouts.border'),
+      $container->get('kingly_layouts.animation'),
+      $container->get('kingly_layouts.background'),
+      $container->get('kingly_layouts.shadows_effects'),
+      $container->get('kingly_layouts.responsiveness'),
+      $container->get('kingly_layouts.custom_attributes')
     );
   }
 
@@ -120,810 +115,25 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
     $form = parent::buildConfigurationForm($form, $form_state);
 
-    // Get color options once, as it's used in multiple places.
-    $color_options = $this->getColorOptions();
-
-    // Get sizing options for this layout.
     $sizing_options = $this->getSizingOptions();
-    // Get the currently configured sizing option.
-    $default_sizing_option = $this->configuration['sizing_option'];
+    $default_sizing = $this->configuration['sizing_option'] ?? key($sizing_options);
 
-    // Fallback for invalid sizing option.
-    if (!isset($sizing_options[$default_sizing_option])) {
-      $default_sizing_option = key($sizing_options);
-    }
-
-    // Column Sizing.
     $form['sizing_option'] = [
       '#type' => 'select',
       '#title' => $this->t('Column sizing'),
       '#options' => $sizing_options,
-      '#default_value' => $default_sizing_option,
+      '#default_value' => $default_sizing,
       '#description' => $this->t('Select the desired column width distribution.'),
       '#weight' => -10,
       '#access' => $this->currentUser->hasPermission('administer kingly layouts sizing'),
     ];
 
-    // Container Type.
-    $form['container_type'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Container Type'),
-      '#options' => $this->getOptions('container_type'),
-      '#default_value' => $this->configuration['container_type'],
-      '#description' => $this->t("Select how the layout container should behave: <br> <strong>Boxed:</strong> Standard container with a maximum width. <br> <strong>Full Width (Background Only):</strong> The background spans the full viewport width, but the content remains aligned with the site's main content area. Horizontal padding will be applied *within* this content area. <br> <strong>Edge to Edge (Full Bleed):</strong> Both the background and content span the full viewport width. <br> <strong>Full Screen Hero:</strong> The section fills the entire viewport height and width."),
-      '#weight' => -9,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts container type'),
-    ];
-
-    // Delegate form elements to services.
-    $form = $this->spacingService->buildConfigurationForm($form, $form_state, $this->configuration);
-    $form = $this->alignmentService->buildConfigurationForm($form, $form_state, $this->configuration);
-
-    // Colors.
-    $form['colors'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Colors'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts colors'),
-    ];
-    if (count($color_options) > 1) {
-      // Background color and opacity moved to 'background' group.
-      $form['colors']['foreground_color'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Foreground Color'),
-        '#options' => $color_options,
-        '#default_value' => $this->configuration['foreground_color'],
-      ];
-      $form['colors']['color_info'] = [
-        '#type' => 'item',
-        '#markup' => $this->t('Colors are managed in the <a href="/admin/structure/taxonomy/manage/@vocab_id/overview" target="_blank">Kingly CSS Color</a> vocabulary.', ['@vocab_id' => self::KINGLY_CSS_COLOR_VOCABULARY]),
-      ];
+    // Delegate form building to each service.
+    foreach ($this->displayOptionServices as $service) {
+      $form = $service->buildConfigurationForm($form, $form_state, $this->configuration);
     }
-    else {
-      $form['colors']['color_info'] = [
-        '#type' => 'item',
-        '#title' => $this->t('Color Options'),
-        '#markup' => $this->t('No colors defined. Please <a href="/admin/structure/taxonomy/manage/@vocab_id/add" target="_blank">add terms</a> to the "Kingly CSS Color" vocabulary.', ['@vocab_id' => self::KINGLY_CSS_COLOR_VOCABULARY]),
-      ];
-    }
-
-    // Borders.
-    $form['border'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Border'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts border'),
-    ];
-    if (count($color_options) > 1) {
-      $form['border']['border_color'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Border Color'),
-        '#options' => $color_options,
-        '#default_value' => $this->configuration['border_color'],
-        '#description' => $this->t('Selecting a color will enable the border options below.'),
-      ];
-    }
-    $form['border']['border_width_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Border Width'),
-      '#options' => $this->getOptions('border_width'),
-      '#default_value' => $this->configuration['border_width_option'],
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[border][border_color]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-    $form['border']['border_style_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Border Style'),
-      '#options' => $this->getOptions('border_style'),
-      '#default_value' => $this->configuration['border_style_option'],
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[border][border_color]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-    $form['border']['border_radius_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Border Radius'),
-      '#options' => $this->getOptions('border_radius'),
-      '#default_value' => $this->configuration['border_radius_option'],
-    ];
-
-    // Animation Options.
-    $form['animation'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Animation'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts animation'),
-    ];
-    $form['animation']['animation_type'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Animation Type'),
-      '#options' => $this->getOptions('animation_type'),
-      '#default_value' => $this->configuration['animation_type'],
-      '#description' => $this->t('Select an animation to apply when the layout scrolls into view. This defines the start and end states.'),
-    ];
-    $form['animation']['slide_direction'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Slide Direction'),
-      '#options' => $this->getOptions('slide_direction'),
-      '#default_value' => $this->configuration['slide_direction'],
-      '#description' => $this->t('Select the direction for slide-in animations.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[animation][animation_type]"]' => ['value' => 'slide-in'],
-        ],
-      ],
-    ];
-    $form['animation']['transition_property'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Transition Property'),
-      '#options' => $this->getOptions('transition_property'),
-      '#default_value' => $this->configuration['transition_property'],
-      '#description' => $this->t('The CSS property that the transition will animate.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-    $form['animation']['transition_duration'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Transition Duration'),
-      '#options' => $this->getOptions('transition_duration'),
-      '#default_value' => $this->configuration['transition_duration'],
-      '#description' => $this->t('How long the animation takes to complete.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-    $form['animation']['transition_timing_function'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Transition Speed Curve'),
-      '#options' => $this->getOptions('transition_timing_function'),
-      '#default_value' => $this->configuration['transition_timing_function'],
-      '#description' => $this->t('The speed curve of the animation.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-    $form['animation']['transition_delay'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Transition Delay'),
-      '#options' => $this->getOptions('transition_delay'),
-      '#default_value' => $this->configuration['transition_delay'],
-      '#description' => $this->t('The delay before the animation starts.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-
-    // Background.
-    $form['background'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Background'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts background'),
-    ];
-
-    // --- Main Type Selector ---
-    $form['background']['background_type'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Background Type'),
-      '#options' => $this->getOptions('background_type'),
-      '#default_value' => $this->configuration['background_type'],
-      '#description' => $this->t('Choose the type of background for this layout section.'),
-    ];
-
-    // Consolidated background_media_min_height field.
-    $form['background']['background_media_min_height'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Minimum Height'),
-      '#default_value' => $this->configuration['background_media_min_height'],
-      '#description' => $this->t('Set a minimum height for the section. Include the unit (e.g., 400px, 50vh). Leave blank for default height.'),
-      '#states' => [
-        'visible' => [
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'image']],
-          'or',
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'video']],
-          'or',
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient']],
-        ],
-        'disabled' => [
-          ':input[name="layout_settings[container_type]"]' => ['value' => 'hero'],
-        ],
-      ],
-      // Place after background_type.
-      '#weight' => 1,
-    ];
-
-    // --- Color Settings ---
-    $form['background']['color_settings'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Color Options'),
-      '#open' => TRUE,
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'color'],
-        ],
-      ],
-    ];
-    if (count($color_options) > 1) {
-      $form['background']['color_settings']['background_color'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Background Color'),
-        '#options' => $color_options,
-        '#default_value' => $this->configuration['background_color'],
-      ];
-      $form['background']['color_settings']['background_opacity'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Background Opacity'),
-        '#options' => $this->getOptions('background_opacity'),
-        '#default_value' => $this->configuration['background_opacity'],
-        '#description' => $this->t('Set the opacity for the background color. This requires a background color to be selected.'),
-        '#states' => [
-          'visible' => [
-            ':input[name="layout_settings[background][color_settings][background_color]"]' => ['!value' => self::NONE_OPTION_KEY],
-          ],
-        ],
-      ];
-    }
-
-    // --- Overlay Settings (Common for Image, Video, Gradient) ---
-    $form['background']['overlay_settings'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Background Overlay'),
-      '#open' => TRUE,
-      '#states' => [
-        'visible' => [
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'image']],
-          'or',
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'video']],
-          'or',
-          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient']],
-        ],
-      ],
-    ];
-    $form['background']['overlay_settings']['background_overlay_color'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Overlay Color'),
-      '#options' => $color_options,
-      '#default_value' => $this->configuration['background_overlay_color'],
-      '#description' => $this->t('Select a color for the overlay. The overlay sits on top of the background media, but behind the content.'),
-    ];
-    $form['background']['overlay_settings']['background_overlay_opacity'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Overlay Opacity'),
-      '#options' => $this->getOptions('background_overlay_opacity'),
-      '#default_value' => $this->configuration['background_overlay_opacity'],
-      '#description' => $this->t('Set the opacity for the overlay color. This requires an overlay color to be selected.'),
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][overlay_settings][background_overlay_color]"]' => ['!value' => self::NONE_OPTION_KEY],
-        ],
-      ],
-    ];
-
-    // --- Image Settings ---
-    $form['background']['image_settings'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Image Options'),
-      '#open' => TRUE,
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'image'],
-        ],
-      ],
-    ];
-    $form['background']['image_settings']['background_media_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Image URL'),
-      '#default_value' => $this->configuration['background_media_url'],
-      '#description' => $this->t('Enter the full, absolute URL for the background image.'),
-    ];
-    $form['background']['image_settings']['background_image_position'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Image Position'),
-      '#options' => $this->getOptions('background_image_position'),
-      '#default_value' => $this->configuration['background_image_position'],
-      '#description' => $this->t("Select the starting position of the background image. This is most noticeable when the image is not set to 'cover' or 'contain'."),
-    ];
-    $form['background']['image_settings']['background_image_repeat'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Image Repeat'),
-      '#options' => $this->getOptions('background_image_repeat'),
-      '#default_value' => $this->configuration['background_image_repeat'],
-      '#description' => $this->t('Define if and how the background image should repeat.'),
-    ];
-    $form['background']['image_settings']['background_image_size'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Image Size'),
-      '#options' => $this->getOptions('background_image_size'),
-      '#default_value' => $this->configuration['background_image_size'],
-      '#description' => $this->t("'Cover' will fill the entire area, potentially cropping the image. 'Contain' will show the entire image, potentially leaving empty space."),
-    ];
-    $form['background']['image_settings']['background_image_attachment'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Image Attachment'),
-      '#options' => $this->getOptions('background_image_attachment'),
-      '#default_value' => $this->configuration['background_image_attachment'],
-      '#description' => $this->t("Define how the background image behaves when scrolling. 'Fixed' creates a parallax-like effect."),
-    ];
-
-    // --- Video Settings ---
-    $form['background']['video_settings'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Video Options'),
-      '#open' => TRUE,
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'video'],
-        ],
-      ],
-    ];
-    $form['background']['video_settings']['background_media_url'] = [
-      '#type' => 'url',
-      '#title' => $this->t('Video URL'),
-      '#default_value' => $this->configuration['background_media_url'],
-      '#description' => $this->t('Enter the full, absolute URL for the video file (e.g., https://example.com/video.mp4). YouTube or Vimeo URLs are not supported.'),
-    ];
-    $form['background']['video_settings']['background_video_loop'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Loop video'),
-      '#default_value' => $this->configuration['background_video_loop'],
-    ];
-    $form['background']['video_settings']['background_video_autoplay'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Autoplay video'),
-      '#default_value' => $this->configuration['background_video_autoplay'],
-    ];
-    $form['background']['video_settings']['background_video_muted'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Mute video'),
-      '#default_value' => $this->configuration['background_video_muted'],
-    ];
-    $form['background']['video_settings']['background_video_preload'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Preload video'),
-      '#options' => [
-        'auto' => $this->t('Auto'),
-        'metadata' => $this->t('Metadata only'),
-        'none' => $this->t('None'),
-      ],
-      '#default_value' => $this->configuration['background_video_preload'],
-    ];
-
-    // --- Gradient Settings ---
-    $form['background']['gradient_settings'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Gradient Options'),
-      '#open' => TRUE,
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient'],
-        ],
-      ],
-    ];
-    $form['background']['gradient_settings']['background_gradient_type'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Gradient Type'),
-      '#options' => $this->getOptions('background_gradient_type'),
-      '#default_value' => $this->configuration['background_gradient_type'],
-    ];
-    $form['background']['gradient_settings']['background_gradient_start_color'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Start Color'),
-      '#options' => $color_options,
-      '#default_value' => $this->configuration['background_gradient_start_color'],
-    ];
-    $form['background']['gradient_settings']['background_gradient_end_color'] = [
-      '#type' => 'select',
-      '#title' => $this->t('End Color'),
-      '#options' => $color_options,
-      '#default_value' => $this->configuration['background_gradient_end_color'],
-    ];
-    $form['background']['gradient_settings']['linear_gradient_settings'] = [
-      '#type' => 'container',
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][gradient_settings][background_gradient_type]"]' => ['value' => 'linear'],
-        ],
-      ],
-    ];
-    $form['background']['gradient_settings']['linear_gradient_settings']['background_gradient_linear_direction'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Direction'),
-      '#options' => $this->getOptions('background_gradient_linear_direction'),
-      '#default_value' => $this->configuration['background_gradient_linear_direction'],
-    ];
-    $form['background']['gradient_settings']['radial_gradient_settings'] = [
-      '#type' => 'container',
-      '#states' => [
-        'visible' => [
-          ':input[name="layout_settings[background][gradient_settings][background_gradient_type]"]' => ['value' => 'radial'],
-        ],
-      ],
-    ];
-    $form['background']['gradient_settings']['radial_gradient_settings']['background_gradient_radial_shape'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Shape'),
-      '#options' => $this->getOptions('background_gradient_radial_shape'),
-      '#default_value' => $this->configuration['background_gradient_radial_shape'],
-    ];
-    $form['background']['gradient_settings']['radial_gradient_settings']['background_gradient_radial_position'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Position'),
-      '#options' => $this->getOptions('background_gradient_radial_position'),
-      '#default_value' => $this->configuration['background_gradient_radial_position'],
-    ];
-
-    // Shadows & Effects.
-    $form['shadows_effects'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Shadows & Effects'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts shadows effects'),
-    ];
-    $form['shadows_effects']['box_shadow_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Box Shadow'),
-      '#options' => $this->getOptions('box_shadow'),
-      '#default_value' => $this->configuration['box_shadow_option'],
-    ];
-    $form['shadows_effects']['filter_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Filter'),
-      '#options' => $this->getOptions('filter'),
-      '#default_value' => $this->configuration['filter_option'],
-    ];
-    // New fields for Shadows & Effects.
-    $form['shadows_effects']['opacity_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Opacity'),
-      '#options' => $this->getOptions('opacity'),
-      '#default_value' => $this->configuration['opacity_option'],
-      '#description' => $this->t('Adjust the overall transparency of the layout section.'),
-    ];
-    $form['shadows_effects']['transform_scale_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Scale'),
-      '#options' => $this->getOptions('transform_scale'),
-      '#default_value' => $this->configuration['transform_scale_option'],
-      '#description' => $this->t('Scale the size of the layout section.'),
-    ];
-    $form['shadows_effects']['transform_rotate_option'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Rotate'),
-      '#options' => $this->getOptions('transform_rotate'),
-      '#default_value' => $this->configuration['transform_rotate_option'],
-      '#description' => $this->t('Rotate the layout section.'),
-    ];
-
-    // Responsiveness.
-    $form['responsiveness'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Responsiveness'),
-      '#open' => FALSE,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts responsiveness'),
-    ];
-    $form['responsiveness']['hide_on_breakpoint'] = [
-      '#type' => 'checkboxes',
-      '#title' => $this->t('Hide on Breakpoint'),
-      '#options' => $this->getOptions('hide_on_breakpoint'),
-      '#default_value' => $this->configuration['hide_on_breakpoint'],
-      '#description' => $this->t('Hide this entire layout section on specific screen sizes.'),
-    ];
-
-    // Custom Attributes.
-    $form['custom_attributes'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Custom Attributes'),
-      '#open' => FALSE,
-      '#weight' => 100,
-      '#access' => $this->currentUser->hasPermission('administer kingly layouts custom attributes'),
-    ];
-    $form['custom_attributes']['custom_css_id'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Custom ID'),
-      '#default_value' => $this->configuration['custom_css_id'],
-      '#description' => $this->t('Enter a unique ID for this layout section (e.g., `my-unique-section`). Must be unique on the page and contain only letters, numbers, hyphens, and underscores.'),
-    ];
-    $form['custom_attributes']['custom_css_class'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Custom CSS Classes'),
-      '#default_value' => $this->configuration['custom_css_class'],
-      '#description' => $this->t('Add one or more custom CSS classes to this layout section, separated by spaces (e.g., `my-custom-class another-class`).'),
-    ];
 
     return $form;
-  }
-
-  /**
-   * Returns color options from the 'kingly_css_color' vocabulary.
-   *
-   * @return array
-   *   An associative array of color options.
-   */
-  protected function getColorOptions(): array {
-    $cid = 'kingly_layouts:color_options';
-    if ($cache = $this->cache->get($cid)) {
-      return $cache->data;
-    }
-
-    $options = [
-      self::NONE_OPTION_KEY => $this->t('None'),
-    ];
-
-    // The vocabulary config entity itself is a cache dependency.
-    $cache_tags = ['config:taxonomy.vocabulary.' . self::KINGLY_CSS_COLOR_VOCABULARY];
-
-    if ($this->entityTypeManager->getStorage('taxonomy_vocabulary')
-      ->load(self::KINGLY_CSS_COLOR_VOCABULARY)) {
-      // The list of terms in the vocabulary is also a cache dependency.
-      $cache_tags[] = 'taxonomy_term_list:' . self::KINGLY_CSS_COLOR_VOCABULARY;
-      $terms = $this->termStorage->loadTree(self::KINGLY_CSS_COLOR_VOCABULARY, 0, NULL, TRUE);
-      foreach ($terms as $term) {
-        $options[$term->id()] = $term->getName();
-      }
-    }
-
-    $this->cache->set($cid, $options, CacheBackendInterface::CACHE_PERMANENT, $cache_tags);
-
-    return $options;
-  }
-
-  /**
-   * Returns the available sizing options for this layout.
-   *
-   * @return array
-   *   An associative array of sizing options.
-   */
-  abstract protected function getSizingOptions(): array;
-
-  /**
-   * Returns an array of options for a given key.
-   *
-   * This method consolidates many small get...Options() methods into one.
-   *
-   * @param string $key
-   *   The key for the options array to retrieve.
-   *
-   * @return array
-   *   An associative array of options.
-   */
-  private function getOptions(string $key): array {
-    $none = [self::NONE_OPTION_KEY => $this->t('None')];
-
-    // Special case for border_radius which combines scale options with another.
-    if ($key === 'border_radius') {
-      return $this->getScaleOptions() + ['full' => $this->t('Full (Pill/Circle)')];
-    }
-
-    $options = [
-      'container_type' => [
-        'boxed' => $this->t('Boxed'),
-        'full' => $this->t('Full Width (Background Only)'),
-        'edge-to-edge' => $this->t('Edge to Edge (Full Bleed)'),
-        'hero' => $this->t('Full Screen Hero'),
-      ],
-      'border_width' => $none + [
-        'sm' => $this->t('Small (1px)'),
-        'md' => $this->t('Medium (2px)'),
-        'lg' => $this->t('Large (4px)'),
-      ],
-      'border_style' => $none + [
-        'solid' => $this->t('Solid'),
-        'dashed' => $this->t('Dashed'),
-        'dotted' => $this->t('Dotted'),
-      ],
-      'vertical_alignment' => [
-        'stretch' => $this->t('Stretch'),
-        'flex-start' => $this->t('Top'),
-        'center' => $this->t('Center (Default)'),
-        'flex-end' => $this->t('Bottom'),
-        'baseline' => $this->t('Baseline'),
-      ],
-      'horizontal_alignment' => [
-        'start' => $this->t('Start (Left)'),
-        'center' => $this->t('Center'),
-        'end' => $this->t('End (Right)'),
-        'space-between' => $this->t('Space Between'),
-        'space-around' => $this->t('Space Around'),
-        'space-evenly' => $this->t('Space Evenly'),
-      ],
-      'animation_type' => $none + [
-        'fade-in' => $this->t('Fade In'),
-        'slide-in' => $this->t('Slide In'),
-      ],
-      'slide_direction' => $none + [
-        'up' => $this->t('Bottom up'),
-        'down' => $this->t('Top down'),
-        'left' => $this->t('Right to Left'),
-        'right' => $this->t('Left to Right'),
-      ],
-      'transition_property' => [
-        self::NONE_OPTION_KEY => $this->t('Default (opacity, transform)'),
-        'opacity' => $this->t('Opacity only'),
-        'transform' => $this->t('Transform only'),
-        'all' => $this->t('All properties'),
-        'opacity, transform' => $this->t('Opacity and Transform'),
-      ],
-      'transition_duration' => [
-        self::NONE_OPTION_KEY => $this->t('Default (600ms)'),
-        '150ms' => $this->t('150ms'),
-        '300ms' => $this->t('300ms'),
-        '500ms' => $this->t('500ms'),
-        '750ms' => $this->t('750ms'),
-        '1s' => $this->t('1s'),
-      ],
-      'transition_timing_function' => [
-        self::NONE_OPTION_KEY => $this->t('Default (ease-out)'),
-        'ease' => $this->t('ease'),
-        'ease-in' => $this->t('ease-in'),
-        'ease-in-out' => $this->t('ease-in-out'),
-        'linear' => $this->t('linear'),
-      ],
-      'transition_delay' => $none + [
-        '150ms' => $this->t('150ms'),
-        '300ms' => $this->t('300ms'),
-        '500ms' => $this->t('500ms'),
-        '750ms' => $this->t('750ms'),
-        '1s' => $this->t('1s'),
-      ],
-      'background_type' => [
-        'color' => $this->t('Color'),
-        'image' => $this->t('Image'),
-        'video' => $this->t('Video'),
-        'gradient' => $this->t('Gradient'),
-      ],
-      'background_opacity' => [
-        self::NONE_OPTION_KEY => $this->t('100% (Default)'),
-        '90' => $this->t('90%'),
-        '75' => $this->t('75%'),
-        '50' => $this->t('50%'),
-        '25' => $this->t('25%'),
-        '0' => $this->t('0% (Transparent)'),
-      ],
-      'background_overlay_opacity' => $none + [
-        '25' => $this->t('25%'),
-        '50' => $this->t('50%'),
-        '75' => $this->t('75%'),
-        '90' => $this->t('90%'),
-      ],
-      'background_image_position' => [
-        'center center' => $this->t('Center Center'),
-        'center top' => $this->t('Center Top'),
-        'center bottom' => $this->t('Center Bottom'),
-        'left top' => $this->t('Left Top'),
-        'left center' => $this->t('Left Center'),
-        'left bottom' => $this->t('Left Bottom'),
-        'right top' => $this->t('Right Top'),
-        'right center' => $this->t('Right Center'),
-        'right bottom' => $this->t('Right Bottom'),
-      ],
-      'background_image_repeat' => [
-        'no-repeat' => $this->t('No Repeat'),
-        'repeat' => $this->t('Repeat'),
-        'repeat-x' => $this->t('Repeat Horizontally'),
-        'repeat-y' => $this->t('Repeat Vertically'),
-      ],
-      'background_image_size' => [
-        'cover' => $this->t('Cover'),
-        'contain' => $this->t('Contain'),
-        'auto' => $this->t('Auto'),
-      ],
-      'background_image_attachment' => [
-        'scroll' => $this->t('Scroll'),
-        'fixed' => $this->t('Fixed (Parallax)'),
-        'local' => $this->t('Local'),
-      ],
-      'background_gradient_type' => [
-        'linear' => $this->t('Linear'),
-        'radial' => $this->t('Radial'),
-      ],
-      'background_gradient_linear_direction' => [
-        'to bottom' => $this->t('To Bottom (Default)'),
-        'to top' => $this->t('To Top'),
-        'to right' => $this->t('To Right'),
-        'to left' => $this->t('To Left'),
-        'to bottom right' => $this->t('To Bottom Right'),
-        'to top left' => $this->t('To Top Left'),
-        '45deg' => $this->t('45 Degrees'),
-        '90deg' => $this->t('90 Degrees (To Right)'),
-        '135deg' => $this->t('135 Degrees'),
-        '180deg' => $this->t('180 Degrees (To Top)'),
-        '225deg' => $this->t('225 Degrees'),
-        '270deg' => $this->t('270 Degrees (To Left)'),
-        '315deg' => $this->t('315 Degrees'),
-      ],
-      'background_gradient_radial_shape' => [
-        'ellipse' => $this->t('Ellipse (Default)'),
-        'circle' => $this->t('Circle'),
-      ],
-      'background_gradient_radial_position' => [
-        'center' => $this->t('Center (Default)'),
-        'top' => $this->t('Top'),
-        'bottom' => $this->t('Bottom'),
-        'left' => $this->t('Left'),
-        'right' => $this->t('Right'),
-        'top left' => $this->t('Top Left'),
-        'top right' => $this->t('Top Right'),
-        'bottom left' => $this->t('Bottom Left'),
-        'bottom right' => $this->t('Bottom Right'),
-      ],
-      'box_shadow' => $none + [
-        'sm' => $this->t('Small'),
-        'md' => $this->t('Medium'),
-        'lg' => $this->t('Large'),
-        'xl' => $this->t('Extra Large'),
-        'inner' => $this->t('Inner'),
-      ],
-      'filter' => $none + [
-        'grayscale' => $this->t('Grayscale'),
-        'blur' => $this->t('Blur'),
-        'sepia' => $this->t('Sepia'),
-        'brightness' => $this->t('Brightness'),
-      ],
-      'opacity' => [
-        self::NONE_OPTION_KEY => $this->t('100% (Default)'),
-        '0.9' => $this->t('90%'),
-        '0.75' => $this->t('75%'),
-        '0.5' => $this->t('50%'),
-        '0.25' => $this->t('25%'),
-        '0' => $this->t('0% (Transparent)'),
-      ],
-      'transform_scale' => [
-        self::NONE_OPTION_KEY => $this->t('None (100%)'),
-        '0.9' => $this->t('90%'),
-        '0.95' => $this->t('95%'),
-        '1.05' => $this->t('105%'),
-        '1.1' => $this->t('110%'),
-        '1.25' => $this->t('125%'),
-      ],
-      'transform_rotate' => $none + [
-        '1' => $this->t('1 degree'),
-        '2' => $this->t('2 degrees'),
-        '3' => $this->t('3 degrees'),
-        '5' => $this->t('5 degrees'),
-        '-1' => $this->t('-1 degree'),
-        '-2' => $this->t('-2 degrees'),
-        '-3' => $this->t('-3 degrees'),
-        '-5' => $this->t('-5 degrees'),
-      ],
-      'hide_on_breakpoint' => [
-        'mobile' => $this->t('Mobile'),
-        'tablet' => $this->t('Tablet'),
-        'desktop' => $this->t('Desktop'),
-      ],
-    ];
-
-    return $options[$key] ?? [];
-  }
-
-  /**
-   * Returns the available padding scale options.
-   *
-   * @return array
-   *   An associative array of padding scale options.
-   */
-  protected function getScaleOptions(): array {
-    return [
-      self::NONE_OPTION_KEY => $this->t('None'),
-      'xs' => $this->t('Extra Small (0.25rem)'),
-      'sm' => $this->t('Small (0.5rem)'),
-      'md' => $this->t('Medium (1rem)'),
-      'lg' => $this->t('Large (2rem)'),
-      'xl' => $this->t('Extra Large (4rem)'),
-    ];
   }
 
   /**
@@ -931,115 +141,10 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
     parent::submitConfigurationForm($form, $form_state);
-
-    $values = $form_state->getValues();
-
-    // Handle settings not managed by a service.
-    foreach (['sizing_option', 'container_type'] as $key) {
-      $this->configuration[$key] = $values[$key];
+    $this->configuration['sizing_option'] = $form_state->getValue('sizing_option');
+    foreach ($this->displayOptionServices as $service) {
+      $service->submitConfigurationForm($form, $form_state, $this->configuration);
     }
-
-    // Delegate form submission to services.
-    $this->spacingService->submitConfigurationForm($form, $form_state, $this->configuration);
-    $this->alignmentService->submitConfigurationForm($form, $form_state, $this->configuration);
-
-    // The rest of the submission logic for other setting groups.
-    $this->configuration['foreground_color'] = $values['colors']['foreground_color'] ?? self::NONE_OPTION_KEY;
-
-    foreach ([
-      'border_color',
-      'border_width_option',
-      'border_style_option',
-      'border_radius_option',
-    ] as $key) {
-      $this->configuration[$key] = $values['border'][$key] ?? self::NONE_OPTION_KEY;
-    }
-
-    foreach ([
-      'animation_type',
-      'slide_direction',
-      'transition_property',
-      'transition_duration',
-      'transition_timing_function',
-      'transition_delay',
-    ] as $key) {
-      $this->configuration[$key] = $values['animation'][$key];
-    }
-
-    // --- Background Settings ---
-    $background_values = $values['background'];
-    $this->configuration['background_type'] = $background_values['background_type'];
-
-    // Consolidate shared fields based on background type.
-    $media_url = '';
-    $min_height = $background_values['background_media_min_height'] ?? '';
-
-    switch ($this->configuration['background_type']) {
-      case 'image':
-        $media_url = $background_values['image_settings']['background_media_url'] ?? '';
-        break;
-
-      case 'video':
-        $media_url = $background_values['video_settings']['background_media_url'] ?? '';
-        break;
-    }
-
-    $this->configuration['background_media_url'] = $media_url;
-    $this->configuration['background_media_min_height'] = ($values['container_type'] === 'hero') ? '' : $min_height;
-
-    // Color settings.
-    $this->configuration['background_color'] = $background_values['color_settings']['background_color'] ?? self::NONE_OPTION_KEY;
-    $this->configuration['background_opacity'] = $background_values['color_settings']['background_opacity'] ?? self::NONE_OPTION_KEY;
-
-    // Image settings.
-    foreach ([
-      'background_image_position',
-      'background_image_repeat',
-      'background_image_size',
-      'background_image_attachment',
-    ] as $key) {
-      $this->configuration[$key] = $background_values['image_settings'][$key] ?? $this->defaultConfiguration()[$key];
-    }
-
-    // Video settings.
-    foreach ([
-      'background_video_loop',
-      'background_video_autoplay',
-      'background_video_muted',
-      'background_video_preload',
-    ] as $key) {
-      $this->configuration[$key] = $background_values['video_settings'][$key] ?? $this->defaultConfiguration()[$key];
-    }
-
-    // Gradient settings.
-    $this->configuration['background_gradient_type'] = $background_values['gradient_settings']['background_gradient_type'] ?? 'linear';
-    $this->configuration['background_gradient_start_color'] = $background_values['gradient_settings']['background_gradient_start_color'] ?? self::NONE_OPTION_KEY;
-    $this->configuration['background_gradient_end_color'] = $background_values['gradient_settings']['background_gradient_end_color'] ?? self::NONE_OPTION_KEY;
-    $this->configuration['background_gradient_linear_direction'] = $background_values['gradient_settings']['linear_gradient_settings']['background_gradient_linear_direction'] ?? 'to bottom';
-    $this->configuration['background_gradient_radial_shape'] = $background_values['gradient_settings']['radial_gradient_settings']['background_gradient_radial_shape'] ?? 'ellipse';
-    $this->configuration['background_gradient_radial_position'] = $background_values['gradient_settings']['radial_gradient_settings']['background_gradient_radial_position'] ?? 'center';
-
-    // Overlay settings.
-    $this->configuration['background_overlay_color'] = $background_values['overlay_settings']['background_overlay_color'] ?? self::NONE_OPTION_KEY;
-    $this->configuration['background_overlay_opacity'] = $background_values['overlay_settings']['background_overlay_opacity'] ?? self::NONE_OPTION_KEY;
-
-    // Shadows & Effects.
-    foreach ([
-      'box_shadow_option',
-      'filter_option',
-      'opacity_option',
-      'transform_scale_option',
-      'transform_rotate_option',
-    ] as $key) {
-      $this->configuration[$key] = $values['shadows_effects'][$key];
-    }
-
-    // Responsiveness.
-    $this->configuration['hide_on_breakpoint'] = array_filter($values['responsiveness']['hide_on_breakpoint']);
-
-    // Custom Attributes.
-    $this->configuration['custom_css_id'] = trim($values['custom_attributes']['custom_css_id']);
-    $this->configuration['custom_css_class'] = trim($values['custom_attributes']['custom_css_class']);
   }
 
   /**
@@ -1047,82 +152,22 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
    */
   public function defaultConfiguration(): array {
     $configuration = parent::defaultConfiguration();
-
-    // Set a safe, generic default for sizing.
     $configuration['sizing_option'] = 'default';
 
-    // Set the default for the container type.
-    $configuration['container_type'] = 'boxed';
-
-    // Manually set spacing defaults. These values must not come from an
-    // injected service, as this method can be called before the service
-    // is initialized.
-    $configuration['horizontal_padding_option'] = self::NONE_OPTION_KEY;
-    $configuration['vertical_padding_option'] = self::NONE_OPTION_KEY;
-    $configuration['gap_option'] = self::NONE_OPTION_KEY;
-    $configuration['horizontal_margin_option'] = self::NONE_OPTION_KEY;
-    $configuration['vertical_margin_option'] = self::NONE_OPTION_KEY;
-
-    // Manually set alignment defaults.
-    $configuration['vertical_alignment'] = 'center';
-    $configuration['horizontal_alignment'] = 'start';
-
-    // --- Defaults for other setting groups (to be refactored later) ---
-    // Colors.
-    $configuration['background_color'] = self::NONE_OPTION_KEY;
-    $configuration['background_opacity'] = self::NONE_OPTION_KEY;
-    $configuration['foreground_color'] = self::NONE_OPTION_KEY;
-
-    // Borders.
-    $configuration['border_radius_option'] = self::NONE_OPTION_KEY;
-    $configuration['border_color'] = self::NONE_OPTION_KEY;
-    $configuration['border_width_option'] = self::NONE_OPTION_KEY;
-    $configuration['border_style_option'] = self::NONE_OPTION_KEY;
-
-    // Animation.
-    $configuration['animation_type'] = self::NONE_OPTION_KEY;
-    $configuration['slide_direction'] = self::NONE_OPTION_KEY;
-    $configuration['transition_property'] = self::NONE_OPTION_KEY;
-    $configuration['transition_duration'] = self::NONE_OPTION_KEY;
-    $configuration['transition_timing_function'] = self::NONE_OPTION_KEY;
-    $configuration['transition_delay'] = self::NONE_OPTION_KEY;
-
-    // Background Media.
-    $configuration['background_type'] = 'color';
-    $configuration['background_media_url'] = '';
-    $configuration['background_media_min_height'] = '';
-    $configuration['background_image_position'] = 'center center';
-    $configuration['background_image_repeat'] = 'no-repeat';
-    $configuration['background_image_size'] = 'cover';
-    $configuration['background_image_attachment'] = 'scroll';
-    $configuration['background_video_loop'] = FALSE;
-    $configuration['background_video_autoplay'] = TRUE;
-    $configuration['background_video_muted'] = TRUE;
-    $configuration['background_video_preload'] = 'auto';
-    $configuration['background_overlay_color'] = self::NONE_OPTION_KEY;
-    $configuration['background_overlay_opacity'] = self::NONE_OPTION_KEY;
-
-    // Background Gradient.
-    $configuration['background_gradient_type'] = 'linear';
-    $configuration['background_gradient_start_color'] = self::NONE_OPTION_KEY;
-    $configuration['background_gradient_end_color'] = self::NONE_OPTION_KEY;
-    $configuration['background_gradient_linear_direction'] = 'to bottom';
-    $configuration['background_gradient_radial_shape'] = 'ellipse';
-    $configuration['background_gradient_radial_position'] = 'center';
-
-    // Shadows & Effects.
-    $configuration['box_shadow_option'] = self::NONE_OPTION_KEY;
-    $configuration['filter_option'] = self::NONE_OPTION_KEY;
-    $configuration['opacity_option'] = self::NONE_OPTION_KEY;
-    $configuration['transform_scale_option'] = self::NONE_OPTION_KEY;
-    $configuration['transform_rotate_option'] = self::NONE_OPTION_KEY;
-
-    // Responsiveness.
-    $configuration['hide_on_breakpoint'] = [];
-
-    // Custom Attributes.
-    $configuration['custom_css_id'] = '';
-    $configuration['custom_css_class'] = '';
+    // Merge defaults from each service's static method.
+    $configuration = array_merge(
+      $configuration,
+      ContainerTypeService::defaultConfiguration(),
+      SpacingService::defaultConfiguration(),
+      ColorService::defaultConfiguration(),
+      BorderService::defaultConfiguration(),
+      AlignmentService::defaultConfiguration(),
+      AnimationService::defaultConfiguration(),
+      BackgroundService::defaultConfiguration(),
+      ShadowsEffectsService::defaultConfiguration(),
+      ResponsivenessService::defaultConfiguration(),
+      CustomAttributesService::defaultConfiguration()
+    );
 
     return $configuration;
   }
@@ -1132,320 +177,32 @@ abstract class KinglyLayoutBase extends LayoutDefault implements PluginFormInter
    */
   public function build(array $regions): array {
     $build = parent::build($regions);
-
+    $build['#attributes']['class'] = $build['#attributes']['class'] ?? [];
+    $build['#attributes']['style'] = $build['#attributes']['style'] ?? [];
     $build['#attached']['library'][] = 'kingly_layouts/kingly_utilities';
 
-    $plugin_definition = $this->getPluginDefinition();
-    $layout_id = $plugin_definition->id();
-
-    // Add layout-specific sizing class.
     if (!empty($this->configuration['sizing_option']) && $this->configuration['sizing_option'] !== 'default') {
+      $layout_id = $this->getPluginDefinition()->id();
       $build['#attributes']['class'][] = 'layout--' . $layout_id . '--' . $this->configuration['sizing_option'];
     }
 
-    // Delegate processing to services.
-    $this->spacingService->processBuild($build, $this->configuration);
-    $this->alignmentService->processBuild($build, $this->configuration);
-
-    // Apply the main class for the container type.
-    if (!empty($this->configuration['container_type'])) {
-      $build['#attributes']['class'][] = 'kingly-layout--' . $this->configuration['container_type'];
+    foreach ($this->displayOptionServices as $service) {
+      $service->processBuild($build, $this->configuration);
     }
 
-    // Apply classes from a map for other settings.
-    $class_map = [
-      'border_radius_option' => 'kingly-layout-border-radius-',
-      'box_shadow_option' => 'kingly-layout-shadow-',
-      'filter_option' => 'kingly-layout-filter-',
-    ];
-    foreach ($class_map as $config_key => $prefix) {
-      // Pass the configuration array to use the method from the trait.
-      $this->applyClassFromConfig($build, $prefix, $config_key, $this->configuration);
+    if (empty($build['#attributes']['style'])) {
+      unset($build['#attributes']['style']);
     }
-
-    // Apply background media (image, video, or gradient).
-    $this->applyBackgroundMedia($build);
-
-    // Apply inline styles from a map.
-    $style_map = [
-      'opacity_option' => 'opacity',
-    ];
-    foreach ($style_map as $config_key => $property) {
-      $this->applyInlineStyleFromOption($build, $property, $config_key);
-    }
-
-    // Handle combined transforms.
-    $transforms = [];
-    if (($scale_value = $this->configuration['transform_scale_option']) !== self::NONE_OPTION_KEY) {
-      $transforms[] = 'scale(' . $scale_value . ')';
-    }
-    if (($rotate_value = $this->configuration['transform_rotate_option']) !== self::NONE_OPTION_KEY) {
-      $transforms[] = 'rotate(' . $rotate_value . 'deg)';
-    }
-    if (!empty($transforms)) {
-      $build['#attributes']['style'][] = 'transform: ' . implode(' ', $transforms) . ';';
-    }
-
-    // Apply responsiveness classes.
-    if (!empty($this->configuration['hide_on_breakpoint'])) {
-      foreach ($this->configuration['hide_on_breakpoint'] as $breakpoint) {
-        if ($breakpoint) {
-          $build['#attributes']['class'][] = 'kingly-layout-hide-on-' . $breakpoint;
-        }
-      }
-    }
-
-    // Apply background color with opacity.
-    if ($this->configuration['background_type'] === 'color' && ($background_color_hex = $this->getTermColorHex($this->configuration['background_color']))) {
-      $background_opacity_value = $this->configuration['background_opacity'];
-      if ($background_opacity_value !== self::NONE_OPTION_KEY && ($rgb = $this->hexToRgb($background_color_hex))) {
-        $alpha = (float) $background_opacity_value / 100;
-        $build['#attributes']['style'][] = "background-color: rgba({$rgb[0]}, {$rgb[1]}, {$rgb[2]}, {$alpha});";
-      }
-      else {
-        $build['#attributes']['style'][] = 'background-color: ' . $background_color_hex . ';';
-      }
-    }
-
-    // Apply foreground color.
-    $this->applyStyleFromConfig($build, 'color', 'foreground_color');
-
-    // Apply border styles.
-    if ($border_color_hex = $this->getTermColorHex($this->configuration['border_color'])) {
-      $build['#attributes']['style'][] = 'border-color: ' . $border_color_hex . ';';
-      $border_width = $this->configuration['border_width_option'] !== self::NONE_OPTION_KEY ? $this->configuration['border_width_option'] : 'sm';
-      $border_style = $this->configuration['border_style_option'] !== self::NONE_OPTION_KEY ? $this->configuration['border_style_option'] : 'solid';
-      $this->applyClassFromConfig($build, 'kingly-layout-border-width-', $border_width, $this->configuration);
-      $this->applyClassFromConfig($build, 'kingly-layout-border-style-', $border_style, $this->configuration);
-    }
-
-    // Apply animation.
-    if ($this->configuration['animation_type'] !== self::NONE_OPTION_KEY) {
-      $build['#attached']['library'][] = 'kingly_layouts/kingly_animations';
-      $build['#attributes']['class'][] = 'kingly-animate';
-      $this->applyClassFromConfig($build, 'kingly-animate--', 'animation_type', $this->configuration);
-
-      if ($this->configuration['animation_type'] === 'slide-in' && $this->configuration['slide_direction'] !== self::NONE_OPTION_KEY) {
-        $this->applyClassFromConfig($build, 'kingly-animate--direction-', 'slide_direction', $this->configuration);
-      }
-
-      $animation_style_map = [
-        'transition_property' => 'transition-property',
-        'transition_duration' => 'transition-duration',
-        'transition_timing_function' => 'transition-timing-function',
-        'transition_delay' => 'transition-delay',
-      ];
-      foreach ($animation_style_map as $config_key => $property) {
-        $this->applyInlineStyleFromOption($build, $property, $config_key);
-      }
-    }
-
-    // Apply custom CSS ID and classes.
-    if (!empty($this->configuration['custom_css_id'])) {
-      $build['#attributes']['id'] = $this->configuration['custom_css_id'];
-    }
-    if (!empty($this->configuration['custom_css_class'])) {
-      $build['#attributes']['class'] = array_merge($build['#attributes']['class'], explode(' ', $this->configuration['custom_css_class']));
+    if (empty($build['#attributes']['class'])) {
+      unset($build['#attributes']['class']);
     }
 
     return $build;
   }
 
   /**
-   * Helper to apply a CSS class from a configuration value.
-   *
-   * The suffix for the class is determined by the value of the configuration
-   * key provided. This method can also accept a direct string value instead of
-   * a configuration key.
-   *
-   * @param array &$build
-   *   The render array.
-   * @param string $class_prefix
-   *   The prefix for the CSS class (e.g., 'kingly-layout-padding-x-').
-   * @param string $config_key_or_value
-   *   The configuration key (e.g., 'horizontal_padding_option') or a direct
-   *   string value (e.g., 'sm') to use for the class suffix.
+   * Returns the available sizing options for this layout.
    */
-  private function applyClassFromConfig(array &$build, string $class_prefix, string $config_key_or_value): void {
-    // Check if the provided string is a config key or a direct value.
-    $value = $this->configuration[$config_key_or_value] ?? $config_key_or_value;
-    if (!empty($value) && $value !== self::NONE_OPTION_KEY) {
-      $build['#attributes']['class'][] = $class_prefix . $value;
-    }
-  }
-
-  /**
-   * Applies background media styles and elements to the build array.
-   *
-   * @param array &$build
-   *   The render array.
-   */
-  private function applyBackgroundMedia(array &$build): void {
-    $background_type = $this->configuration['background_type'];
-    $media_url = $this->configuration['background_media_url'];
-    $min_height = $this->configuration['background_media_min_height'];
-
-    // Apply min-height if set for a media background (image, video, or
-    // gradient).
-    if (!empty($min_height) && in_array($background_type, [
-      'image',
-      'video',
-      'gradient',
-    ])) {
-      $build['#attributes']['style'][] = 'min-height: ' . $min_height . ';';
-    }
-
-    // Handle background image or video.
-    if (!empty($media_url)) {
-      if ($background_type === 'image') {
-        $build['#attributes']['style'][] = 'background-image: url("' . $media_url . '");';
-        $this->applyInlineStyleFromOption($build, 'background-position', 'background_image_position');
-        $this->applyInlineStyleFromOption($build, 'background-repeat', 'background_image_repeat');
-        $this->applyInlineStyleFromOption($build, 'background-size', 'background_image_size');
-        $this->applyInlineStyleFromOption($build, 'background-attachment', 'background_image_attachment');
-      }
-      elseif ($background_type === 'video') {
-        $build['#attributes']['class'][] = 'kingly-layout--has-bg-video';
-        $build['video_background'] = [
-          '#theme' => 'kingly_background_video',
-          '#video_url' => $media_url,
-          '#loop' => $this->configuration['background_video_loop'],
-          '#autoplay' => $this->configuration['background_video_autoplay'],
-          '#muted' => $this->configuration['background_video_muted'],
-          '#preload' => $this->configuration['background_video_preload'],
-          '#weight' => -100,
-        ];
-      }
-    }
-    // Handle background gradient.
-    elseif ($background_type === 'gradient') {
-      $start_color_hex = $this->getTermColorHex($this->configuration['background_gradient_start_color']);
-      $end_color_hex = $this->getTermColorHex($this->configuration['background_gradient_end_color']);
-
-      if ($start_color_hex && $end_color_hex) {
-        $gradient_type = $this->configuration['background_gradient_type'];
-        if ($gradient_type === 'linear') {
-          $direction = $this->configuration['background_gradient_linear_direction'];
-          $gradient_css = "linear-gradient({$direction}, {$start_color_hex}, {$end_color_hex})";
-        }
-        else {
-          $shape = $this->configuration['background_gradient_radial_shape'];
-          $position = $this->configuration['background_gradient_radial_position'];
-          $gradient_css = "radial-gradient({$shape} at {$position}, {$start_color_hex}, {$end_color_hex})";
-        }
-        $build['#attributes']['style'][] = 'background-image: ' . $gradient_css . ';';
-      }
-    }
-
-    // Handle overlay for image, video, or gradient backgrounds.
-    if (in_array($background_type, ['image', 'video', 'gradient'])) {
-      $overlay_color_hex = $this->getTermColorHex($this->configuration['background_overlay_color']);
-      $overlay_opacity_value = $this->configuration['background_overlay_opacity'];
-
-      if ($overlay_color_hex && $overlay_opacity_value !== self::NONE_OPTION_KEY) {
-        $build['#attributes']['class'][] = 'kingly-layout--has-bg-overlay';
-        $build['overlay'] = [
-          '#type' => 'container',
-          '#attributes' => [
-            'class' => ['kingly-layout__bg-overlay'],
-            'style' => [
-              'background-color: ' . $overlay_color_hex . ';',
-              'opacity: ' . ((float) $overlay_opacity_value / 100) . ';',
-            ],
-          ],
-          '#weight' => -99,
-        ];
-      }
-    }
-  }
-
-  /**
-   * Helper to apply a generic inline style from a configuration option.
-   *
-   * @param array &$build
-   *   The render array.
-   * @param string $style_property
-   *   The CSS property to set (e.g., 'transition-duration').
-   * @param string $config_key
-   *   The configuration key whose value will be used.
-   */
-  private function applyInlineStyleFromOption(array &$build, string $style_property, string $config_key): void {
-    $value = $this->configuration[$config_key];
-    if ($value !== self::NONE_OPTION_KEY) {
-      $build['#attributes']['style'][] = $style_property . ': ' . $value . ';';
-    }
-  }
-
-  /**
-   * Retrieves the hex color value from a Kingly CSS Color taxonomy term.
-   *
-   * @param string $term_id
-   *   The ID of the taxonomy term.
-   *
-   * @return string|null
-   *   The hex color string if found and valid, NULL otherwise.
-   */
-  protected function getTermColorHex(string $term_id): ?string {
-    if (empty($term_id) || $term_id === self::NONE_OPTION_KEY) {
-      return NULL;
-    }
-
-    /** @var \Drupal\taxonomy\TermInterface $term */
-    $term = $this->termStorage->load($term_id);
-
-    if ($term instanceof TermInterface &&
-      $term->bundle() === self::KINGLY_CSS_COLOR_VOCABULARY &&
-      $term->hasField(self::KINGLY_CSS_COLOR_FIELD) &&
-      !$term->get(self::KINGLY_CSS_COLOR_FIELD)->isEmpty()) {
-      return $term->get(self::KINGLY_CSS_COLOR_FIELD)->value;
-    }
-
-    return NULL;
-  }
-
-  /**
-   * Converts a hex color string to an RGB array.
-   *
-   * @param string $hex
-   *   The hex color string (e.g., "#RRGGBB" or "RRGGBB").
-   *
-   * @return array|null
-   *   An array [R, G, B] if successful, NULL otherwise.
-   */
-  protected function hexToRgb(string $hex): ?array {
-    $hex = ltrim($hex, '#');
-
-    if (strlen($hex) === 3) {
-      $r = hexdec(str_repeat(substr($hex, 0, 1), 2));
-      $g = hexdec(str_repeat(substr($hex, 1, 1), 2));
-      $b = hexdec(str_repeat(substr($hex, 2, 1), 2));
-    }
-    elseif (strlen($hex) === 6) {
-      $r = hexdec(substr($hex, 0, 2));
-      $g = hexdec(substr($hex, 2, 2));
-      $b = hexdec(substr($hex, 4, 2));
-    }
-    else {
-      return NULL;
-    }
-
-    return [$r, $g, $b];
-  }
-
-  /**
-   * Helper to apply an inline style from a configuration value.
-   *
-   * @param array &$build
-   *   The render array.
-   * @param string $style_property
-   *   The CSS property to set.
-   * @param string $config_key
-   *   The configuration key for the color term ID.
-   */
-  private function applyStyleFromConfig(array &$build, string $style_property, string $config_key): void {
-    if ($color_hex = $this->getTermColorHex($this->configuration[$config_key])) {
-      $build['#attributes']['style'][] = $style_property . ': ' . $color_hex . ';';
-    }
-  }
+  abstract protected function getSizingOptions(): array;
 
 }

--- a/src/Service/AlignmentService.php
+++ b/src/Service/AlignmentService.php
@@ -23,16 +23,24 @@ class AlignmentService implements KinglyLayoutsDisplayOptionInterface {
   protected AccountInterface $currentUser;
 
   /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
    * Constructs a new AlignmentService object.
    *
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
    */
-  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation) {
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service) {
     $this->currentUser = $current_user;
     $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
   }
 
   /**
@@ -49,7 +57,7 @@ class AlignmentService implements KinglyLayoutsDisplayOptionInterface {
     $form['alignment']['vertical_alignment'] = [
       '#type' => 'select',
       '#title' => $this->t('Vertical Alignment'),
-      '#options' => $this->getVerticalAlignmentOptions(),
+      '#options' => $this->optionsService->getOptions('vertical_alignment'),
       '#default_value' => $configuration['vertical_alignment'],
       '#description' => $this->t('Align content vertically within the layout. This assumes the layout uses Flexbox or Grid. "Stretch" makes columns in the same row equal height.'),
     ];
@@ -57,7 +65,7 @@ class AlignmentService implements KinglyLayoutsDisplayOptionInterface {
     $form['alignment']['horizontal_alignment'] = [
       '#type' => 'select',
       '#title' => $this->t('Horizontal Alignment'),
-      '#options' => $this->getHorizontalAlignmentOptions(),
+      '#options' => $this->optionsService->getOptions('horizontal_alignment'),
       '#default_value' => $configuration['horizontal_alignment'],
       '#description' => $this->t('Justify content horizontally within the layout. This assumes the layout uses Flexbox or Grid.'),
     ];
@@ -86,43 +94,10 @@ class AlignmentService implements KinglyLayoutsDisplayOptionInterface {
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration(): array {
+  public static function defaultConfiguration(): array {
     return [
       'vertical_alignment' => 'center',
       'horizontal_alignment' => 'start',
-    ];
-  }
-
-  /**
-   * Gets the options for vertical alignment.
-   *
-   * @return array
-   *   An associative array of options.
-   */
-  private function getVerticalAlignmentOptions(): array {
-    return [
-      'stretch' => $this->t('Stretch'),
-      'flex-start' => $this->t('Top'),
-      'center' => $this->t('Center (Default)'),
-      'flex-end' => $this->t('Bottom'),
-      'baseline' => $this->t('Baseline'),
-    ];
-  }
-
-  /**
-   * Gets the options for horizontal alignment.
-   *
-   * @return array
-   *   An associative array of options.
-   */
-  private function getHorizontalAlignmentOptions(): array {
-    return [
-      'start' => $this->t('Start (Left)'),
-      'center' => $this->t('Center'),
-      'end' => $this->t('End (Right)'),
-      'space-between' => $this->t('Space Between'),
-      'space-around' => $this->t('Space Around'),
-      'space-evenly' => $this->t('Space Evenly'),
     ];
   }
 

--- a/src/Service/AnimationService.php
+++ b/src/Service/AnimationService.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+
+/**
+ * Service to manage animation options for Kingly Layouts.
+ */
+class AnimationService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+  use KinglyLayoutsUtilityTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * Constructs a new AnimationService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['animation'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Animation'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts animation'),
+    ];
+
+    $form['animation']['animation_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Animation Type'),
+      '#options' => $this->optionsService->getOptions('animation_type'),
+      '#default_value' => $configuration['animation_type'],
+      '#description' => $this->t('Select an animation to apply when the layout scrolls into view. This defines the start and end states.'),
+    ];
+
+    $form['animation']['slide_direction'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Slide Direction'),
+      '#options' => $this->optionsService->getOptions('slide_direction'),
+      '#default_value' => $configuration['slide_direction'],
+      '#description' => $this->t('Select the direction for slide-in animations.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[animation][animation_type]"]' => ['value' => 'slide-in'],
+        ],
+      ],
+    ];
+
+    $form['animation']['transition_property'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Transition Property'),
+      '#options' => $this->optionsService->getOptions('transition_property'),
+      '#default_value' => $configuration['transition_property'],
+      '#description' => $this->t('The CSS property that the transition will animate.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+
+    $form['animation']['transition_duration'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Transition Duration'),
+      '#options' => $this->optionsService->getOptions('transition_duration'),
+      '#default_value' => $configuration['transition_duration'],
+      '#description' => $this->t('How long the animation takes to complete.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+
+    $form['animation']['transition_timing_function'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Transition Speed Curve'),
+      '#options' => $this->optionsService->getOptions('transition_timing_function'),
+      '#default_value' => $configuration['transition_timing_function'],
+      '#description' => $this->t('The speed curve of the animation.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+
+    $form['animation']['transition_delay'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Transition Delay'),
+      '#options' => $this->optionsService->getOptions('transition_delay'),
+      '#default_value' => $configuration['transition_delay'],
+      '#description' => $this->t('The delay before the animation starts.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[animation][animation_type]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('animation', []);
+    foreach ([
+      'animation_type',
+      'slide_direction',
+      'transition_property',
+      'transition_duration',
+      'transition_timing_function',
+      'transition_delay',
+    ] as $key) {
+      $configuration[$key] = $values[$key] ?? self::NONE_OPTION_KEY;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    if ($configuration['animation_type'] !== self::NONE_OPTION_KEY) {
+      $build['#attached']['library'][] = 'kingly_layouts/kingly_animations';
+      $build['#attributes']['class'][] = 'kingly-animate';
+      $this->applyClassFromConfig($build, 'kingly-animate--', 'animation_type', $configuration);
+
+      if ($configuration['animation_type'] === 'slide-in' && $configuration['slide_direction'] !== self::NONE_OPTION_KEY) {
+        $this->applyClassFromConfig($build, 'kingly-animate--direction-', 'slide_direction', $configuration);
+      }
+
+      $animation_style_map = [
+        'transition_property' => 'transition-property',
+        'transition_duration' => 'transition-duration',
+        'transition_timing_function' => 'transition-timing-function',
+        'transition_delay' => 'transition-delay',
+      ];
+      foreach ($animation_style_map as $config_key => $property) {
+        $this->applyInlineStyleFromOption($build, $property, $config_key, $configuration);
+      }
+    }
+  }
+
+  /**
+   * Helper to apply a generic inline style from a configuration option.
+   *
+   * @param array &$build
+   *   The render array.
+   * @param string $style_property
+   *   The CSS property to set (e.g., 'transition-duration').
+   * @param string $config_key
+   *   The configuration key whose value will be used.
+   * @param array $configuration
+   *   The layout's current configuration.
+   */
+  private function applyInlineStyleFromOption(array &$build, string $style_property, string $config_key, array $configuration): void {
+    $value = $configuration[$config_key];
+    if ($value !== self::NONE_OPTION_KEY) {
+      $build['#attributes']['style'][] = $style_property . ': ' . $value . ';';
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'animation_type' => self::NONE_OPTION_KEY,
+      'slide_direction' => self::NONE_OPTION_KEY,
+      'transition_property' => self::NONE_OPTION_KEY,
+      'transition_duration' => self::NONE_OPTION_KEY,
+      'transition_timing_function' => self::NONE_OPTION_KEY,
+      'transition_delay' => self::NONE_OPTION_KEY,
+    ];
+  }
+
+}

--- a/src/Service/BackgroundService.php
+++ b/src/Service/BackgroundService.php
@@ -1,0 +1,547 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Service to manage background options for Kingly Layouts.
+ */
+class BackgroundService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * The color service.
+   */
+  protected ColorService $colorService;
+
+  /**
+   * Constructs a new BackgroundService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   * @param \Drupal\kingly_layouts\Service\ColorService $color_service
+   *   The color service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service, ColorService $color_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+    $this->colorService = $color_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $color_options = $this->optionsService->getColorOptions();
+
+    $form['background'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Background'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts background'),
+    ];
+
+    // --- Main Type Selector ---
+    $form['background']['background_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Background Type'),
+      '#options' => $this->optionsService->getOptions('background_type'),
+      '#default_value' => $configuration['background_type'],
+      '#description' => $this->t('Choose the type of background for this layout section.'),
+    ];
+
+    // Consolidated background_media_min_height field.
+    $form['background']['background_media_min_height'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Minimum Height'),
+      '#default_value' => $configuration['background_media_min_height'],
+      '#description' => $this->t('Set a minimum height for the section. Include the unit (e.g., 400px, 50vh). Leave blank for default height.'),
+      '#states' => [
+        'visible' => [
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'image']],
+          'or',
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'video']],
+          'or',
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient']],
+        ],
+        'disabled' => [
+          ':input[name="layout_settings[container_type]"]' => ['value' => 'hero'],
+        ],
+      ],
+      // Place after background_type.
+      '#weight' => 1,
+    ];
+
+    // --- Color Settings ---
+    $form['background']['color_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Color Options'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'color'],
+        ],
+      ],
+    ];
+    if (count($color_options) > 1) {
+      $form['background']['color_settings']['background_color'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Background Color'),
+        '#options' => $color_options,
+        '#default_value' => $configuration['background_color'],
+      ];
+      $form['background']['color_settings']['background_opacity'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Background Opacity'),
+        '#options' => $this->optionsService->getOptions('background_opacity'),
+        '#default_value' => $configuration['background_opacity'],
+        '#description' => $this->t('Set the opacity for the background color. This requires a background color to be selected.'),
+        '#states' => [
+          'visible' => [
+            ':input[name="layout_settings[background][color_settings][background_color]"]' => ['!value' => self::NONE_OPTION_KEY],
+          ],
+        ],
+      ];
+    }
+
+    // --- Overlay Settings (Common for Image, Video, Gradient) ---
+    $form['background']['overlay_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Background Overlay'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'image']],
+          'or',
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'video']],
+          'or',
+          [':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient']],
+        ],
+      ],
+    ];
+    $form['background']['overlay_settings']['background_overlay_color'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Overlay Color'),
+      '#options' => $color_options,
+      '#default_value' => $configuration['background_overlay_color'],
+      '#description' => $this->t('Select a color for the overlay. The overlay sits on top of the background media, but behind the content.'),
+    ];
+    $form['background']['overlay_settings']['background_overlay_opacity'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Overlay Opacity'),
+      '#options' => $this->optionsService->getOptions('background_overlay_opacity'),
+      '#default_value' => $configuration['background_overlay_opacity'],
+      '#description' => $this->t('Set the opacity for the overlay color. This requires an overlay color to be selected.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][overlay_settings][background_overlay_color]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+
+    // --- Image Settings ---
+    $form['background']['image_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Image Options'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'image'],
+        ],
+      ],
+    ];
+    $form['background']['image_settings']['background_media_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Image URL'),
+      '#default_value' => $configuration['background_media_url'],
+      '#description' => $this->t('Enter the full, absolute URL for the background image.'),
+    ];
+    $form['background']['image_settings']['background_image_position'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Image Position'),
+      '#options' => $this->optionsService->getOptions('background_image_position'),
+      '#default_value' => $configuration['background_image_position'],
+      '#description' => $this->t("Select the starting position of the background image. This is most noticeable when the image is not set to 'cover' or 'contain'."),
+    ];
+    $form['background']['image_settings']['background_image_repeat'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Image Repeat'),
+      '#options' => $this->optionsService->getOptions('background_image_repeat'),
+      '#default_value' => $configuration['background_image_repeat'],
+      '#description' => $this->t('Define if and how the background image should repeat.'),
+    ];
+    $form['background']['image_settings']['background_image_size'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Image Size'),
+      '#options' => $this->optionsService->getOptions('background_image_size'),
+      '#default_value' => $configuration['background_image_size'],
+      '#description' => $this->t("'Cover' will fill the entire area, potentially cropping the image. 'Contain' will show the entire image, potentially leaving empty space."),
+    ];
+    $form['background']['image_settings']['background_image_attachment'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Image Attachment'),
+      '#options' => $this->optionsService->getOptions('background_image_attachment'),
+      '#default_value' => $configuration['background_image_attachment'],
+      '#description' => $this->t("Define how the background image behaves when scrolling. 'Fixed' creates a parallax-like effect."),
+    ];
+
+    // --- Video Settings ---
+    $form['background']['video_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Video Options'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'video'],
+        ],
+      ],
+    ];
+    $form['background']['video_settings']['background_media_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Video URL'),
+      '#default_value' => $configuration['background_media_url'],
+      '#description' => $this->t('Enter the full, absolute URL for the video file (e.g., https://example.com/video.mp4). YouTube or Vimeo URLs are not supported.'),
+    ];
+    $form['background']['video_settings']['background_video_loop'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Loop video'),
+      '#default_value' => $configuration['background_video_loop'],
+    ];
+    $form['background']['video_settings']['background_video_autoplay'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Autoplay video'),
+      '#default_value' => $configuration['background_video_autoplay'],
+    ];
+    $form['background']['video_settings']['background_video_muted'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Mute video'),
+      '#default_value' => $configuration['background_video_muted'],
+    ];
+    $form['background']['video_settings']['background_video_preload'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Preload video'),
+      '#options' => [
+        'auto' => $this->t('Auto'),
+        'metadata' => $this->t('Metadata only'),
+        'none' => $this->t('None'),
+      ],
+      '#default_value' => $configuration['background_video_preload'],
+    ];
+
+    // --- Gradient Settings ---
+    $form['background']['gradient_settings'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Gradient Options'),
+      '#open' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][background_type]"]' => ['value' => 'gradient'],
+        ],
+      ],
+    ];
+    $form['background']['gradient_settings']['background_gradient_type'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Gradient Type'),
+      '#options' => $this->optionsService->getOptions('background_gradient_type'),
+      '#default_value' => $configuration['background_gradient_type'],
+    ];
+    $form['background']['gradient_settings']['background_gradient_start_color'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Start Color'),
+      '#options' => $color_options,
+      '#default_value' => $configuration['background_gradient_start_color'],
+    ];
+    $form['background']['gradient_settings']['background_gradient_end_color'] = [
+      '#type' => 'select',
+      '#title' => $this->t('End Color'),
+      '#options' => $color_options,
+      '#default_value' => $configuration['background_gradient_end_color'],
+    ];
+    $form['background']['gradient_settings']['linear_gradient_settings'] = [
+      '#type' => 'container',
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][gradient_settings][background_gradient_type]"]' => ['value' => 'linear'],
+        ],
+      ],
+    ];
+    $form['background']['gradient_settings']['linear_gradient_settings']['background_gradient_linear_direction'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Direction'),
+      '#options' => $this->optionsService->getOptions('background_gradient_linear_direction'),
+      '#default_value' => $configuration['background_gradient_linear_direction'],
+    ];
+    $form['background']['gradient_settings']['radial_gradient_settings'] = [
+      '#type' => 'container',
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[background][gradient_settings][background_gradient_type]"]' => ['value' => 'radial'],
+        ],
+      ],
+    ];
+    $form['background']['gradient_settings']['radial_gradient_settings']['background_gradient_radial_shape'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Shape'),
+      '#options' => $this->optionsService->getOptions('background_gradient_radial_shape'),
+      '#default_value' => $configuration['background_gradient_radial_shape'],
+    ];
+    $form['background']['gradient_settings']['radial_gradient_settings']['background_gradient_radial_position'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Position'),
+      '#options' => $this->optionsService->getOptions('background_gradient_radial_position'),
+      '#default_value' => $configuration['background_gradient_radial_position'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValues();
+    $background_values = $values['background'];
+    $configuration['background_type'] = $background_values['background_type'];
+
+    // Consolidate shared fields based on background type.
+    $media_url = '';
+    $min_height = $background_values['background_media_min_height'] ?? '';
+
+    switch ($configuration['background_type']) {
+      case 'image':
+        $media_url = $background_values['image_settings']['background_media_url'] ?? '';
+        break;
+
+      case 'video':
+        $media_url = $background_values['video_settings']['background_media_url'] ?? '';
+        break;
+    }
+
+    $configuration['background_media_url'] = $media_url;
+    $configuration['background_media_min_height'] = ($values['container_type'] === 'hero') ? '' : $min_height;
+
+    // Color settings.
+    $configuration['background_color'] = $background_values['color_settings']['background_color'] ?? self::NONE_OPTION_KEY;
+    $configuration['background_opacity'] = $background_values['color_settings']['background_opacity'] ?? self::NONE_OPTION_KEY;
+
+    // Image settings.
+    $defaults = self::defaultConfiguration();
+    foreach ([
+      'background_image_position',
+      'background_image_repeat',
+      'background_image_size',
+      'background_image_attachment',
+    ] as $key) {
+      $configuration[$key] = $background_values['image_settings'][$key] ?? $defaults[$key];
+    }
+
+    // Video settings.
+    foreach ([
+      'background_video_loop',
+      'background_video_autoplay',
+      'background_video_muted',
+      'background_video_preload',
+    ] as $key) {
+      $configuration[$key] = $background_values['video_settings'][$key] ?? $defaults[$key];
+    }
+
+    // Gradient settings.
+    $configuration['background_gradient_type'] = $background_values['gradient_settings']['background_gradient_type'] ?? 'linear';
+    $configuration['background_gradient_start_color'] = $background_values['gradient_settings']['background_gradient_start_color'] ?? self::NONE_OPTION_KEY;
+    $configuration['background_gradient_end_color'] = $background_values['gradient_settings']['background_gradient_end_color'] ?? self::NONE_OPTION_KEY;
+    $configuration['background_gradient_linear_direction'] = $background_values['gradient_settings']['linear_gradient_settings']['background_gradient_linear_direction'] ?? 'to bottom';
+    $configuration['background_gradient_radial_shape'] = $background_values['gradient_settings']['radial_gradient_settings']['background_gradient_radial_shape'] ?? 'ellipse';
+    $configuration['background_gradient_radial_position'] = $background_values['gradient_settings']['radial_gradient_settings']['background_gradient_radial_position'] ?? 'center';
+
+    // Overlay settings.
+    $configuration['background_overlay_color'] = $background_values['overlay_settings']['background_overlay_color'] ?? self::NONE_OPTION_KEY;
+    $configuration['background_overlay_opacity'] = $background_values['overlay_settings']['background_overlay_opacity'] ?? self::NONE_OPTION_KEY;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    $background_type = $configuration['background_type'];
+    $media_url = $configuration['background_media_url'];
+    $min_height = $configuration['background_media_min_height'];
+
+    if (!empty($min_height) && in_array($background_type, ['image', 'video', 'gradient'])) {
+      $build['#attributes']['style'][] = 'min-height: ' . $min_height . ';';
+    }
+
+    if ($background_type === 'color' && ($background_color_hex = $this->colorService->getTermColorHex($configuration['background_color']))) {
+      $opacity_value = $configuration['background_opacity'];
+      if ($opacity_value !== self::NONE_OPTION_KEY && ($rgb = $this->hexToRgb($background_color_hex))) {
+        $alpha = (float) $opacity_value / 100;
+        $build['#attributes']['style'][] = "background-color: rgba({$rgb[0]}, {$rgb[1]}, {$rgb[2]}, {$alpha});";
+      }
+      else {
+        $build['#attributes']['style'][] = 'background-color: ' . $background_color_hex . ';';
+      }
+    }
+
+    if (!empty($media_url)) {
+      if ($background_type === 'image') {
+        $build['#attributes']['style'][] = 'background-image: url("' . $media_url . '");';
+        $this->applyInlineStyleFromOption($build, 'background-position', 'background_image_position', $configuration);
+        $this->applyInlineStyleFromOption($build, 'background-repeat', 'background_image_repeat', $configuration);
+        $this->applyInlineStyleFromOption($build, 'background-size', 'background_image_size', $configuration);
+        $this->applyInlineStyleFromOption($build, 'background-attachment', 'background_image_attachment', $configuration);
+      }
+      elseif ($background_type === 'video') {
+        $build['#attributes']['class'][] = 'kingly-layout--has-bg-video';
+        $build['video_background'] = [
+          '#theme' => 'kingly_background_video',
+          '#video_url' => $media_url,
+          '#loop' => $configuration['background_video_loop'],
+          '#autoplay' => $configuration['background_video_autoplay'],
+          '#muted' => $configuration['background_video_muted'],
+          '#preload' => $configuration['background_video_preload'],
+          '#weight' => -100,
+        ];
+      }
+    }
+    elseif ($background_type === 'gradient') {
+      $start_hex = $this->colorService->getTermColorHex($configuration['background_gradient_start_color']);
+      $end_hex = $this->colorService->getTermColorHex($configuration['background_gradient_end_color']);
+
+      if ($start_hex && $end_hex) {
+        if ($configuration['background_gradient_type'] === 'linear') {
+          $direction = $configuration['background_gradient_linear_direction'];
+          $gradient = "linear-gradient({$direction}, {$start_hex}, {$end_hex})";
+        }
+        else {
+          $shape = $configuration['background_gradient_radial_shape'];
+          $position = $configuration['background_gradient_radial_position'];
+          $gradient = "radial-gradient({$shape} at {$position}, {$start_hex}, {$end_hex})";
+        }
+        $build['#attributes']['style'][] = 'background-image: ' . $gradient . ';';
+      }
+    }
+
+    // Handle overlay.
+    if (in_array($background_type, ['image', 'video', 'gradient'])) {
+      $overlay_hex = $this->colorService->getTermColorHex($configuration['background_overlay_color']);
+      $overlay_opacity = $configuration['background_overlay_opacity'];
+      if ($overlay_hex && $overlay_opacity !== self::NONE_OPTION_KEY) {
+        $build['#attributes']['class'][] = 'kingly-layout--has-bg-overlay';
+        $build['overlay'] = [
+          '#type' => 'container',
+          '#attributes' => [
+            'class' => ['kingly-layout__bg-overlay'],
+            'style' => [
+              'background-color: ' . $overlay_hex . ';',
+              'opacity: ' . ((float) $overlay_opacity / 100) . ';',
+            ],
+          ],
+          '#weight' => -99,
+        ];
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'background_type' => 'color',
+      'background_color' => self::NONE_OPTION_KEY,
+      'background_opacity' => self::NONE_OPTION_KEY,
+      'background_media_url' => '',
+      'background_media_min_height' => '',
+      'background_image_position' => 'center center',
+      'background_image_repeat' => 'no-repeat',
+      'background_image_size' => 'cover',
+      'background_image_attachment' => 'scroll',
+      'background_video_loop' => FALSE,
+      'background_video_autoplay' => TRUE,
+      'background_video_muted' => TRUE,
+      'background_video_preload' => 'auto',
+      'background_overlay_color' => self::NONE_OPTION_KEY,
+      'background_overlay_opacity' => self::NONE_OPTION_KEY,
+      'background_gradient_type' => 'linear',
+      'background_gradient_start_color' => self::NONE_OPTION_KEY,
+      'background_gradient_end_color' => self::NONE_OPTION_KEY,
+      'background_gradient_linear_direction' => 'to bottom',
+      'background_gradient_radial_shape' => 'ellipse',
+      'background_gradient_radial_position' => 'center',
+    ];
+  }
+
+  /**
+   * Converts a hex color string to an RGB array.
+   *
+   * @param string $hex
+   *   The hex color string (e.g., "#RRGGBB" or "RRGGBB").
+   *
+   * @return array|null
+   *   An array [R, G, B] if successful, NULL otherwise.
+   */
+  private function hexToRgb(string $hex): ?array {
+    $hex = ltrim($hex, '#');
+
+    if (strlen($hex) === 3) {
+      $r = hexdec(str_repeat(substr($hex, 0, 1), 2));
+      $g = hexdec(str_repeat(substr($hex, 1, 1), 2));
+      $b = hexdec(str_repeat(substr($hex, 2, 1), 2));
+    }
+    elseif (strlen($hex) === 6) {
+      $r = hexdec(substr($hex, 0, 2));
+      $g = hexdec(substr($hex, 2, 2));
+      $b = hexdec(substr($hex, 4, 2));
+    }
+    else {
+      return NULL;
+    }
+
+    return [$r, $g, $b];
+  }
+
+  /**
+   * Helper to apply a generic inline style from a configuration option.
+   *
+   * @param array &$build
+   *   The render array.
+   * @param string $style_property
+   *   The CSS property to set.
+   * @param string $config_key
+   *   The configuration key whose value will be used.
+   * @param array $configuration
+   *   The layout's current configuration.
+   */
+  private function applyInlineStyleFromOption(array &$build, string $style_property, string $config_key, array $configuration): void {
+    $value = $configuration[$config_key];
+    if ($value !== self::NONE_OPTION_KEY) {
+      $build['#attributes']['style'][] = $style_property . ': ' . $value . ';';
+    }
+  }
+
+}

--- a/src/Service/BorderService.php
+++ b/src/Service/BorderService.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+
+/**
+ * Service to manage border options for Kingly Layouts.
+ */
+class BorderService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+  use KinglyLayoutsUtilityTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * The color service.
+   */
+  protected ColorService $colorService;
+
+  /**
+   * Constructs a new BorderService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   * @param \Drupal\kingly_layouts\Service\ColorService $color_service
+   *   The color service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service, ColorService $color_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+    $this->colorService = $color_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $color_options = $this->optionsService->getColorOptions();
+
+    $form['border'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Border'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts border'),
+    ];
+
+    if (count($color_options) > 1) {
+      $form['border']['border_color'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Border Color'),
+        '#options' => $color_options,
+        '#default_value' => $configuration['border_color'],
+        '#description' => $this->t('Selecting a color will enable the border options below.'),
+      ];
+    }
+    $form['border']['border_width_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Border Width'),
+      '#options' => $this->optionsService->getOptions('border_width'),
+      '#default_value' => $configuration['border_width_option'],
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[border][border_color]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+    $form['border']['border_style_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Border Style'),
+      '#options' => $this->optionsService->getOptions('border_style'),
+      '#default_value' => $configuration['border_style_option'],
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[border][border_color]"]' => ['!value' => self::NONE_OPTION_KEY],
+        ],
+      ],
+    ];
+    $form['border']['border_radius_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Border Radius'),
+      '#options' => $this->optionsService->getOptions('border_radius'),
+      '#default_value' => $configuration['border_radius_option'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('border', []);
+    foreach ([
+      'border_color',
+      'border_width_option',
+      'border_style_option',
+      'border_radius_option',
+    ] as $key) {
+      $configuration[$key] = $values[$key] ?? self::NONE_OPTION_KEY;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    $this->applyClassFromConfig($build, 'kingly-layout-border-radius-', 'border_radius_option', $configuration);
+
+    if ($border_color_hex = $this->colorService->getTermColorHex($configuration['border_color'])) {
+      $build['#attributes']['style'][] = 'border-color: ' . $border_color_hex . ';';
+      $border_width = $configuration['border_width_option'] !== self::NONE_OPTION_KEY ? $configuration['border_width_option'] : 'sm';
+      $border_style = $configuration['border_style_option'] !== self::NONE_OPTION_KEY ? $configuration['border_style_option'] : 'solid';
+      $this->applyClassFromConfig($build, 'kingly-layout-border-width-', $border_width, $configuration);
+      $this->applyClassFromConfig($build, 'kingly-layout-border-style-', $border_style, $configuration);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'border_radius_option' => self::NONE_OPTION_KEY,
+      'border_color' => self::NONE_OPTION_KEY,
+      'border_width_option' => self::NONE_OPTION_KEY,
+      'border_style_option' => self::NONE_OPTION_KEY,
+    ];
+  }
+
+}

--- a/src/Service/ColorService.php
+++ b/src/Service/ColorService.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Service to manage color options for Kingly Layouts.
+ */
+class ColorService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The ID of the taxonomy vocabulary used for CSS colors.
+   */
+  protected const KINGLY_CSS_COLOR_VOCABULARY = 'kingly_css_color';
+
+  /**
+   * The field name on the taxonomy term that stores the hex color value.
+   */
+  protected const KINGLY_CSS_COLOR_FIELD = 'field_kingly_css_color';
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * The term storage.
+   *
+   * @var \Drupal\taxonomy\TermStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * Constructs a new ColorService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service, EntityTypeManagerInterface $entity_type_manager) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+    $this->termStorage = $entity_type_manager->getStorage('taxonomy_term');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $color_options = $this->optionsService->getColorOptions();
+
+    $form['colors'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Colors'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts colors'),
+    ];
+
+    if (count($color_options) > 1) {
+      $form['colors']['foreground_color'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Foreground Color'),
+        '#options' => $color_options,
+        '#default_value' => $configuration['foreground_color'],
+      ];
+      $form['colors']['color_info'] = [
+        '#type' => 'item',
+        '#markup' => $this->t('Colors are managed in the <a href="/admin/structure/taxonomy/manage/@vocab_id/overview" target="_blank">Kingly CSS Color</a> vocabulary.', ['@vocab_id' => self::KINGLY_CSS_COLOR_VOCABULARY]),
+      ];
+    }
+    else {
+      $form['colors']['color_info'] = [
+        '#type' => 'item',
+        '#title' => $this->t('Color Options'),
+        '#markup' => $this->t('No colors defined. Please <a href="/admin/structure/taxonomy/manage/@vocab_id/add" target="_blank">add terms</a> to the "Kingly CSS Color" vocabulary.', ['@vocab_id' => self::KINGLY_CSS_COLOR_VOCABULARY]),
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('colors', []);
+    $configuration['foreground_color'] = $values['foreground_color'] ?? self::NONE_OPTION_KEY;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    if ($color_hex = $this->getTermColorHex($configuration['foreground_color'])) {
+      $build['#attributes']['style'][] = 'color: ' . $color_hex . ';';
+    }
+  }
+
+  /**
+   * Retrieves the hex color value from a Kingly CSS Color taxonomy term.
+   *
+   * @param string $term_id
+   *   The ID of the taxonomy term.
+   *
+   * @return string|null
+   *   The hex color string if found and valid, NULL otherwise.
+   */
+  public function getTermColorHex(string $term_id): ?string {
+    if (empty($term_id) || $term_id === self::NONE_OPTION_KEY) {
+      return NULL;
+    }
+
+    /** @var \Drupal\taxonomy\TermInterface $term */
+    $term = $this->termStorage->load($term_id);
+
+    if ($term instanceof TermInterface &&
+      $term->bundle() === self::KINGLY_CSS_COLOR_VOCABULARY &&
+      $term->hasField(self::KINGLY_CSS_COLOR_FIELD) &&
+      !$term->get(self::KINGLY_CSS_COLOR_FIELD)->isEmpty()) {
+      return $term->get(self::KINGLY_CSS_COLOR_FIELD)->value;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'foreground_color' => self::NONE_OPTION_KEY,
+    ];
+  }
+
+}

--- a/src/Service/ContainerTypeService.php
+++ b/src/Service/ContainerTypeService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+
+/**
+ * Service to manage container type options for Kingly Layouts.
+ */
+class ContainerTypeService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+  use KinglyLayoutsUtilityTrait;
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * Constructs a new ContainerTypeService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['container_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Container Type'),
+      '#options' => $this->optionsService->getOptions('container_type'),
+      '#default_value' => $configuration['container_type'],
+      '#description' => $this->t("Select how the layout container should behave: <br> <strong>Boxed:</strong> Standard container with a maximum width. <br> <strong>Full Width (Background Only):</strong> The background spans the full viewport width, but the content remains aligned with the site's main content area. Horizontal padding will be applied *within* this content area. <br> <strong>Edge to Edge (Full Bleed):</strong> Both the background and content span the full viewport width. <br> <strong>Full Screen Hero:</strong> The section fills the entire viewport height and width."),
+      '#weight' => -9,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts container type'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $configuration['container_type'] = $form_state->getValue('container_type', 'boxed');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    if (!empty($configuration['container_type'])) {
+      $build['#attributes']['class'][] = 'kingly-layout--' . $configuration['container_type'];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'container_type' => 'boxed',
+    ];
+  }
+
+}

--- a/src/Service/CustomAttributesService.php
+++ b/src/Service/CustomAttributesService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Service to manage custom attribute options for Kingly Layouts.
+ */
+class CustomAttributesService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * Constructs a new CustomAttributesService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['custom_attributes'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Custom Attributes'),
+      '#open' => FALSE,
+      '#weight' => 100,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts custom attributes'),
+    ];
+    $form['custom_attributes']['custom_css_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Custom ID'),
+      '#default_value' => $configuration['custom_css_id'],
+      '#description' => $this->t('Enter a unique ID for this layout section (e.g., `my-unique-section`). Must be unique on the page and contain only letters, numbers, hyphens, and underscores.'),
+    ];
+    $form['custom_attributes']['custom_css_class'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Custom CSS Classes'),
+      '#default_value' => $configuration['custom_css_class'],
+      '#description' => $this->t('Add one or more custom CSS classes to this layout section, separated by spaces (e.g., `my-custom-class another-class`).'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('custom_attributes', []);
+    $configuration['custom_css_id'] = trim($values['custom_css_id'] ?? '');
+    $configuration['custom_css_class'] = trim($values['custom_css_class'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    if (!empty($configuration['custom_css_id'])) {
+      $build['#attributes']['id'] = $configuration['custom_css_id'];
+    }
+    if (!empty($configuration['custom_css_class'])) {
+      $build['#attributes']['class'] = array_merge($build['#attributes']['class'] ?? [], explode(' ', $configuration['custom_css_class']));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'custom_css_id' => '',
+      'custom_css_class' => '',
+    ];
+  }
+
+}

--- a/src/Service/DisplayOptionManager.php
+++ b/src/Service/DisplayOptionManager.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\kingly_layouts\Annotation\KinglyLayoutsDisplayOption;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Manages Kingly Layouts display option plugins.
+ *
+ * This manager discovers services tagged with 'kingly_layouts.display_option'
+ * and allows them to be instantiated and used to manage layout settings.
+ *
+ * @see \Drupal\kingly_layouts\Annotation\KinglyLayoutsDisplayOption
+ * @see \Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface
+ */
+class DisplayOptionManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a new DisplayOptionManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    // We are managing services, so the directory is not used.
+    $service_interface = KinglyLayoutsDisplayOptionInterface::class;
+    $plugin_annotation = KinglyLayoutsDisplayOption::class;
+
+    parent::__construct('Service', $namespaces, $module_handler, $service_interface, $plugin_annotation);
+
+    $this->alterInfo('kingly_layouts_display_option_info');
+    $this->setCacheBackend($cache_backend, 'kingly_layouts_display_option_plugins');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processDefinition(&$definition, $plugin_id) {
+    parent::processDefinition($definition, $plugin_id);
+
+    if (empty($definition['id'])) {
+      throw new PluginException(sprintf('The display option plugin "%s" must define an "id" property in its annotation.', $plugin_id));
+    }
+    if (empty($definition['label'])) {
+      throw new PluginException(sprintf('The display option plugin "%s" must define a "label" property in its annotation.', $plugin_id));
+    }
+  }
+
+}

--- a/src/Service/OptionsService.php
+++ b/src/Service/OptionsService.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Provides centralized option lists for layout configuration forms.
+ */
+class OptionsService {
+
+  use StringTranslationTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  public const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The ID of the taxonomy vocabulary used for CSS colors.
+   */
+  protected const KINGLY_CSS_COLOR_VOCABULARY = 'kingly_css_color';
+
+  /**
+   * The entity type manager.
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The term storage.
+   *
+   * @var \Drupal\taxonomy\TermStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * The cache backend.
+   */
+  protected CacheBackendInterface $cache;
+
+  /**
+   * Constructs a new OptionsService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, CacheBackendInterface $cache_backend, TranslationInterface $string_translation) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $this->cache = $cache_backend;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Returns an array of options for a given key.
+   *
+   * @param string $key
+   *   The key for the options array to retrieve.
+   *
+   * @return array
+   *   An associative array of options.
+   */
+  public function getOptions(string $key): array {
+    $none = [self::NONE_OPTION_KEY => $this->t('None')];
+
+    // Special case for border_radius which combines scale options with another.
+    if ($key === 'border_radius') {
+      return $this->getScaleOptions() + ['full' => $this->t('Full (Pill/Circle)')];
+    }
+
+    $options = [
+      'container_type' => [
+        'boxed' => $this->t('Boxed'),
+        'full' => $this->t('Full Width (Background Only)'),
+        'edge-to-edge' => $this->t('Edge to Edge (Full Bleed)'),
+        'hero' => $this->t('Full Screen Hero'),
+      ],
+      'border_width' => $none + [
+        'sm' => $this->t('Small (1px)'),
+        'md' => $this->t('Medium (2px)'),
+        'lg' => $this->t('Large (4px)'),
+      ],
+      'border_style' => $none + [
+        'solid' => $this->t('Solid'),
+        'dashed' => $this->t('Dashed'),
+        'dotted' => $this->t('Dotted'),
+      ],
+      'vertical_alignment' => [
+        'stretch' => $this->t('Stretch'),
+        'flex-start' => $this->t('Top'),
+        'center' => $this->t('Center (Default)'),
+        'flex-end' => $this->t('Bottom'),
+        'baseline' => $this->t('Baseline'),
+      ],
+      'horizontal_alignment' => [
+        'start' => $this->t('Start (Left)'),
+        'center' => $this->t('Center'),
+        'end' => $this->t('End (Right)'),
+        'space-between' => $this->t('Space Between'),
+        'space-around' => $this->t('Space Around'),
+        'space-evenly' => $this->t('Space Evenly'),
+      ],
+      'animation_type' => $none + [
+        'fade-in' => $this->t('Fade In'),
+        'slide-in' => $this->t('Slide In'),
+      ],
+      'slide_direction' => $none + [
+        'up' => $this->t('Bottom up'),
+        'down' => $this->t('Top down'),
+        'left' => $this->t('Right to Left'),
+        'right' => $this->t('Left to Right'),
+      ],
+      'transition_property' => [
+        self::NONE_OPTION_KEY => $this->t('Default (opacity, transform)'),
+        'opacity' => $this->t('Opacity only'),
+        'transform' => $this->t('Transform only'),
+        'all' => $this->t('All properties'),
+        'opacity, transform' => $this->t('Opacity and Transform'),
+      ],
+      'transition_duration' => [
+        self::NONE_OPTION_KEY => $this->t('Default (600ms)'),
+        '150ms' => $this->t('150ms'),
+        '300ms' => $this->t('300ms'),
+        '500ms' => $this->t('500ms'),
+        '750ms' => $this->t('750ms'),
+        '1s' => $this->t('1s'),
+      ],
+      'transition_timing_function' => [
+        self::NONE_OPTION_KEY => $this->t('Default (ease-out)'),
+        'ease' => $this->t('ease'),
+        'ease-in' => $this->t('ease-in'),
+        'ease-in-out' => $this->t('ease-in-out'),
+        'linear' => $this->t('linear'),
+      ],
+      'transition_delay' => $none + [
+        '150ms' => $this->t('150ms'),
+        '300ms' => $this->t('300ms'),
+        '500ms' => $this->t('500ms'),
+        '750ms' => $this->t('750ms'),
+        '1s' => $this->t('1s'),
+      ],
+      'background_type' => [
+        'color' => $this->t('Color'),
+        'image' => $this->t('Image'),
+        'video' => $this->t('Video'),
+        'gradient' => $this->t('Gradient'),
+      ],
+      'background_opacity' => [
+        self::NONE_OPTION_KEY => $this->t('100% (Default)'),
+        '90' => $this->t('90%'),
+        '75' => $this->t('75%'),
+        '50' => $this->t('50%'),
+        '25' => $this->t('25%'),
+        '0' => $this->t('0% (Transparent)'),
+      ],
+      'background_overlay_opacity' => $none + [
+        '25' => $this->t('25%'),
+        '50' => $this->t('50%'),
+        '75' => $this->t('75%'),
+        '90' => $this->t('90%'),
+      ],
+      'background_image_position' => [
+        'center center' => $this->t('Center Center'),
+        'center top' => $this->t('Center Top'),
+        'center bottom' => $this->t('Center Bottom'),
+        'left top' => $this->t('Left Top'),
+        'left center' => $this->t('Left Center'),
+        'left bottom' => $this->t('Left Bottom'),
+        'right top' => $this->t('Right Top'),
+        'right center' => $this->t('Right Center'),
+        'right bottom' => $this->t('Right Bottom'),
+      ],
+      'background_image_repeat' => [
+        'no-repeat' => $this->t('No Repeat'),
+        'repeat' => $this->t('Repeat'),
+        'repeat-x' => $this->t('Repeat Horizontally'),
+        'repeat-y' => $this->t('Repeat Vertically'),
+      ],
+      'background_image_size' => [
+        'cover' => $this->t('Cover'),
+        'contain' => $this->t('Contain'),
+        'auto' => $this->t('Auto'),
+      ],
+      'background_image_attachment' => [
+        'scroll' => $this->t('Scroll'),
+        'fixed' => $this->t('Fixed (Parallax)'),
+        'local' => $this->t('Local'),
+      ],
+      'background_gradient_type' => [
+        'linear' => $this->t('Linear'),
+        'radial' => $this->t('Radial'),
+      ],
+      'background_gradient_linear_direction' => [
+        'to bottom' => $this->t('To Bottom (Default)'),
+        'to top' => $this->t('To Top'),
+        'to right' => $this->t('To Right'),
+        'to left' => $this->t('To Left'),
+        'to bottom right' => $this->t('To Bottom Right'),
+        'to top left' => $this->t('To Top Left'),
+        '45deg' => $this->t('45 Degrees'),
+        '90deg' => $this->t('90 Degrees (To Right)'),
+        '135deg' => $this->t('135 Degrees'),
+        '180deg' => $this->t('180 Degrees (To Top)'),
+        '225deg' => $this->t('225 Degrees'),
+        '270deg' => $this->t('270 Degrees (To Left)'),
+        '315deg' => $this->t('315 Degrees'),
+      ],
+      'background_gradient_radial_shape' => [
+        'ellipse' => $this->t('Ellipse (Default)'),
+        'circle' => $this->t('Circle'),
+      ],
+      'background_gradient_radial_position' => [
+        'center' => $this->t('Center (Default)'),
+        'top' => $this->t('Top'),
+        'bottom' => $this->t('Bottom'),
+        'left' => $this->t('Left'),
+        'right' => $this->t('Right'),
+        'top left' => $this->t('Top Left'),
+        'top right' => $this->t('Top Right'),
+        'bottom left' => $this->t('Bottom Left'),
+        'bottom right' => $this->t('Bottom Right'),
+      ],
+      'box_shadow' => $none + [
+        'sm' => $this->t('Small'),
+        'md' => $this->t('Medium'),
+        'lg' => $this->t('Large'),
+        'xl' => $this->t('Extra Large'),
+        'inner' => $this->t('Inner'),
+      ],
+      'filter' => $none + [
+        'grayscale' => $this->t('Grayscale'),
+        'blur' => $this->t('Blur'),
+        'sepia' => $this->t('Sepia'),
+        'brightness' => $this->t('Brightness'),
+      ],
+      'opacity' => [
+        self::NONE_OPTION_KEY => $this->t('100% (Default)'),
+        '0.9' => $this->t('90%'),
+        '0.75' => $this->t('75%'),
+        '0.5' => $this->t('50%'),
+        '0.25' => $this->t('25%'),
+        '0' => $this->t('0% (Transparent)'),
+      ],
+      'transform_scale' => [
+        self::NONE_OPTION_KEY => $this->t('None (100%)'),
+        '0.9' => $this->t('90%'),
+        '0.95' => $this->t('95%'),
+        '1.05' => $this->t('105%'),
+        '1.1' => $this->t('110%'),
+        '1.25' => $this->t('125%'),
+      ],
+      'transform_rotate' => $none + [
+        '1' => $this->t('1 degree'),
+        '2' => $this->t('2 degrees'),
+        '3' => $this->t('3 degrees'),
+        '5' => $this->t('5 degrees'),
+        '-1' => $this->t('-1 degree'),
+        '-2' => $this->t('-2 degrees'),
+        '-3' => $this->t('-3 degrees'),
+        '-5' => $this->t('-5 degrees'),
+      ],
+      'hide_on_breakpoint' => [
+        'mobile' => $this->t('Mobile'),
+        'tablet' => $this->t('Tablet'),
+        'desktop' => $this->t('Desktop'),
+      ],
+    ];
+
+    return $options[$key] ?? [];
+  }
+
+  /**
+   * Returns color options from the 'kingly_css_color' vocabulary.
+   *
+   * @return array
+   *   An associative array of color options.
+   */
+  public function getColorOptions(): array {
+    $cid = 'kingly_layouts:color_options';
+    if ($cache = $this->cache->get($cid)) {
+      return $cache->data;
+    }
+
+    $options = [
+      self::NONE_OPTION_KEY => $this->t('None'),
+    ];
+
+    // The vocabulary config entity itself is a cache dependency.
+    $cache_tags = ['config:taxonomy.vocabulary.' . self::KINGLY_CSS_COLOR_VOCABULARY];
+
+    if ($this->entityTypeManager->getStorage('taxonomy_vocabulary')
+      ->load(self::KINGLY_CSS_COLOR_VOCABULARY)) {
+      // The list of terms in the vocabulary is also a cache dependency.
+      $cache_tags[] = 'taxonomy_term_list:' . self::KINGLY_CSS_COLOR_VOCABULARY;
+      $terms = $this->termStorage->loadTree(self::KINGLY_CSS_COLOR_VOCABULARY, 0, NULL, TRUE);
+      foreach ($terms as $term) {
+        $options[$term->id()] = $term->getName();
+      }
+    }
+
+    $this->cache->set($cid, $options, CacheBackendInterface::CACHE_PERMANENT, $cache_tags);
+
+    return $options;
+  }
+
+  /**
+   * Returns the available padding scale options.
+   *
+   * @return array
+   *   An associative array of padding scale options.
+   */
+  public function getScaleOptions(): array {
+    return [
+      self::NONE_OPTION_KEY => $this->t('None'),
+      'xs' => $this->t('Extra Small (0.25rem)'),
+      'sm' => $this->t('Small (0.5rem)'),
+      'md' => $this->t('Medium (1rem)'),
+      'lg' => $this->t('Large (2rem)'),
+      'xl' => $this->t('Extra Large (4rem)'),
+    ];
+  }
+
+}

--- a/src/Service/ResponsivenessService.php
+++ b/src/Service/ResponsivenessService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Service to manage responsiveness options for Kingly Layouts.
+ */
+class ResponsivenessService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * Constructs a new ResponsivenessService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['responsiveness'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Responsiveness'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts responsiveness'),
+    ];
+
+    $form['responsiveness']['hide_on_breakpoint'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Hide on Breakpoint'),
+      '#options' => $this->optionsService->getOptions('hide_on_breakpoint'),
+      '#default_value' => $configuration['hide_on_breakpoint'],
+      '#description' => $this->t('Hide this entire layout section on specific screen sizes.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('responsiveness', []);
+    $configuration['hide_on_breakpoint'] = array_filter($values['hide_on_breakpoint'] ?? []);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    if (!empty($configuration['hide_on_breakpoint'])) {
+      foreach ($configuration['hide_on_breakpoint'] as $breakpoint) {
+        if ($breakpoint) {
+          $build['#attributes']['class'][] = 'kingly-layout-hide-on-' . $breakpoint;
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'hide_on_breakpoint' => [],
+    ];
+  }
+
+}

--- a/src/Service/ShadowsEffectsService.php
+++ b/src/Service/ShadowsEffectsService.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+
+/**
+ * Service to manage shadow and effects options for Kingly Layouts.
+ */
+class ShadowsEffectsService implements KinglyLayoutsDisplayOptionInterface {
+
+  use StringTranslationTrait;
+  use KinglyLayoutsUtilityTrait;
+
+  /**
+   * The key used for the "None" option in select lists.
+   */
+  protected const NONE_OPTION_KEY = '_none';
+
+  /**
+   * The current user.
+   */
+  protected AccountInterface $currentUser;
+
+  /**
+   * The options service.
+   */
+  protected OptionsService $optionsService;
+
+  /**
+   * Constructs a new ShadowsEffectsService object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\OptionsService $options_service
+   *   The options service.
+   */
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, OptionsService $options_service) {
+    $this->currentUser = $current_user;
+    $this->stringTranslation = $string_translation;
+    $this->optionsService = $options_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state, array $configuration): array {
+    $form['shadows_effects'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Shadows & Effects'),
+      '#open' => FALSE,
+      '#access' => $this->currentUser->hasPermission('administer kingly layouts shadows effects'),
+    ];
+    $form['shadows_effects']['box_shadow_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Box Shadow'),
+      '#options' => $this->optionsService->getOptions('box_shadow'),
+      '#default_value' => $configuration['box_shadow_option'],
+    ];
+    $form['shadows_effects']['filter_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Filter'),
+      '#options' => $this->optionsService->getOptions('filter'),
+      '#default_value' => $configuration['filter_option'],
+    ];
+    $form['shadows_effects']['opacity_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Opacity'),
+      '#options' => $this->optionsService->getOptions('opacity'),
+      '#default_value' => $configuration['opacity_option'],
+      '#description' => $this->t('Adjust the overall transparency of the layout section.'),
+    ];
+    $form['shadows_effects']['transform_scale_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Scale'),
+      '#options' => $this->optionsService->getOptions('transform_scale'),
+      '#default_value' => $configuration['transform_scale_option'],
+      '#description' => $this->t('Scale the size of the layout section.'),
+    ];
+    $form['shadows_effects']['transform_rotate_option'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Rotate'),
+      '#options' => $this->optionsService->getOptions('transform_rotate'),
+      '#default_value' => $configuration['transform_rotate_option'],
+      '#description' => $this->t('Rotate the layout section.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $values = $form_state->getValue('shadows_effects', []);
+    foreach ([
+      'box_shadow_option',
+      'filter_option',
+      'opacity_option',
+      'transform_scale_option',
+      'transform_rotate_option',
+    ] as $key) {
+      $configuration[$key] = $values[$key] ?? self::NONE_OPTION_KEY;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    $class_map = [
+      'box_shadow_option' => 'kingly-layout-shadow-',
+      'filter_option' => 'kingly-layout-filter-',
+    ];
+    foreach ($class_map as $config_key => $prefix) {
+      $this->applyClassFromConfig($build, $prefix, $config_key, $configuration);
+    }
+
+    $style_map = [
+      'opacity_option' => 'opacity',
+    ];
+    foreach ($style_map as $config_key => $property) {
+      $this->applyInlineStyleFromOption($build, $property, $config_key, $configuration);
+    }
+
+    // Handle combined transforms.
+    $transforms = [];
+    if (($scale_value = $configuration['transform_scale_option']) !== self::NONE_OPTION_KEY) {
+      $transforms[] = 'scale(' . $scale_value . ')';
+    }
+    if (($rotate_value = $configuration['transform_rotate_option']) !== self::NONE_OPTION_KEY) {
+      $transforms[] = 'rotate(' . $rotate_value . 'deg)';
+    }
+    if (!empty($transforms)) {
+      $build['#attributes']['style'][] = 'transform: ' . implode(' ', $transforms) . ';';
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'box_shadow_option' => self::NONE_OPTION_KEY,
+      'filter_option' => self::NONE_OPTION_KEY,
+      'opacity_option' => self::NONE_OPTION_KEY,
+      'transform_scale_option' => self::NONE_OPTION_KEY,
+      'transform_rotate_option' => self::NONE_OPTION_KEY,
+    ];
+  }
+
+  /**
+   * Helper to apply a generic inline style from a configuration option.
+   *
+   * @param array &$build
+   *   The render array.
+   * @param string $style_property
+   *   The CSS property to set.
+   * @param string $config_key
+   *   The configuration key whose value will be used.
+   * @param array $configuration
+   *   The layout's current configuration.
+   */
+  private function applyInlineStyleFromOption(array &$build, string $style_property, string $config_key, array $configuration): void {
+    $value = $configuration[$config_key];
+    if ($value !== self::NONE_OPTION_KEY) {
+      $build['#attributes']['style'][] = $style_property . ': ' . $value . ';';
+    }
+  }
+
+}

--- a/src/Service/SpacingService.php
+++ b/src/Service/SpacingService.php
@@ -125,21 +125,18 @@ class SpacingService implements KinglyLayoutsDisplayOptionInterface {
       'horizontal_margin_option',
       'vertical_margin_option',
     ] as $key) {
-      $configuration[$key] = $spacing_values[$key] ?? $this->defaultConfiguration()[$key];
+      $configuration[$key] = $spacing_values[$key] ?? self::defaultConfiguration()[$key];
     }
   }
 
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration(): array {
-    $padding_options = $this->getScaleOptions();
-    $default_padding = key($padding_options);
-
+  public static function defaultConfiguration(): array {
     return [
-      'horizontal_padding_option' => $default_padding,
-      'vertical_padding_option' => $default_padding,
-      'gap_option' => key($this->getScaleOptions()),
+      'horizontal_padding_option' => self::NONE_OPTION_KEY,
+      'vertical_padding_option' => self::NONE_OPTION_KEY,
+      'gap_option' => self::NONE_OPTION_KEY,
       'horizontal_margin_option' => self::NONE_OPTION_KEY,
       'vertical_margin_option' => self::NONE_OPTION_KEY,
     ];
@@ -161,7 +158,8 @@ class SpacingService implements KinglyLayoutsDisplayOptionInterface {
 
       case 'edge-to-edge':
       case 'hero':
-        $h_padding_effective = self::NONE_OPTION_KEY;
+        // The CSS for these container types handles padding differently.
+        // We only apply the class, and CSS variables do the rest.
         $apply_horizontal_margin = FALSE;
         break;
     }


### PR DESCRIPTION
Refactored the monolithic KinglyLayoutBase class to delegate form building, submission, and build processing for layout settings to a series of dedicated, tagged services.

- Created a KinglyLayoutsDisplayOptionInterface to define the contract for these services.
- Created individual services for each settings category (Spacing, Color, Background, etc.), each implementing the interface.
- Tagged each service with \`kingly_layouts.display_option\`.
- KinglyLayoutBase now injects all tagged services and iterates over them to build the form, handle submission, and process the render array.
- Created a central OptionsService to provide lists of choices (e.g., color palettes, spacing scales) to the other services, reducing code duplication.

This change improves maintainability, separates concerns, and makes it easier to add or modify layout setting categories in the future."