### PR TITLE
fix: correct without filter to prevent layout duplication

### DIFF
--- a/templates/layout--kingly-fourcol.html.twig
+++ b/templates/layout--kingly-fourcol.html.twig
@@ -29,7 +29,7 @@
     if they exist in the content array, respecting their weights.
     This is more maintainable than checking for each element individually.
     #}
-    {{ content|without('content') }}
+    {{ content|without('first', 'second', 'third', 'fourth') }}
 
     {% if content.first %}
       <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>

--- a/templates/layout--kingly-threecol.html.twig
+++ b/templates/layout--kingly-threecol.html.twig
@@ -28,7 +28,7 @@
     if they exist in the content array, respecting their weights.
     This is more maintainable than checking for each element individually.
     #}
-    {{ content|without('content') }}
+    {{ content|without('first', 'second', 'third') }}
 
     {% if content.first %}
       <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>

--- a/templates/layout--kingly-twocol.html.twig
+++ b/templates/layout--kingly-twocol.html.twig
@@ -27,8 +27,8 @@
     if they exist in the content array, respecting their weights.
     This is more maintainable than checking for each element individually.
     #}
-    {{ content|without('content') }}
-    
+    {{ content|without('first', 'second') }}
+
     {% if content.first %}
       <div {{ region_attributes.first.addClass('layout__region', 'layout__region--first') }}>
         {{ content.first }}


### PR DESCRIPTION
Replace content|without('content') with content|without('first', 'second', 'third') to properly exclude region content and prevent duplicated layouts in column templates