### PR TITLE
refactor(services): Centralize color validation logic into a trait

### DIFF
--- a/src/KinglyLayoutsValidationTrait.php
+++ b/src/KinglyLayoutsValidationTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\kingly_layouts;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Provides validation methods for Kingly Layouts services.
+ *
+ * This trait is intended to be used by services that need to validate common
+ * input types, such as color hex codes, to reduce code duplication.
+ */
+trait KinglyLayoutsValidationTrait {
+
+  use StringTranslationTrait;
+
+  /**
+   * Validates a color hex code form element.
+   *
+   * @param array $element
+   *   The form element to validate.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function validateColorHex(array &$element, FormStateInterface $form_state): void {
+    $value = $element['#value'];
+    // Check if a value is provided and if it matches the hex color pattern.
+    // The pattern ensures it starts with '#' and is followed by exactly 6 hex
+    // characters.
+    if (!empty($value) && !preg_match('/^#([a-fA-F0-9]{6})$/', $value)) {
+      $form_state->setError(
+        $element,
+        $this->t('The color must be a valid 6-digit hex code starting with # (e.g., #RRGGBB).')
+      );
+    }
+  }
+
+}

--- a/src/Service/BackgroundService.php
+++ b/src/Service/BackgroundService.php
@@ -9,6 +9,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
 use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+use Drupal\kingly_layouts\KinglyLayoutsValidationTrait;
 
 /**
  * Service to manage background options for Kingly Layouts.
@@ -20,6 +21,7 @@ class BackgroundService implements KinglyLayoutsDisplayOptionInterface {
 
   use StringTranslationTrait;
   use KinglyLayoutsUtilityTrait;
+  use KinglyLayoutsValidationTrait;
 
   /**
    * The current user.
@@ -762,24 +764,6 @@ class BackgroundService implements KinglyLayoutsDisplayOptionInterface {
     }
 
     return [$r, $g, $b];
-  }
-
-  /**
-   * Validates a color hex code form element.
-   *
-   * @param array $element
-   *   The form element to validate.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
-   */
-  public function validateColorHex(array &$element, FormStateInterface $form_state): void {
-    $value = $element['#value'];
-    // Check if a value is provided and if it matches the hex color pattern.
-    // The pattern ensures it starts with '#' and is followed by exactly 6 hex
-    // characters.
-    if (!empty($value) && !preg_match('/^#([a-fA-F0-9]{6})$/', $value)) {
-      $form_state->setError($element, $this->t('The color must be a valid 6-digit hex code starting with # (e.g., #RRGGBB).'));
-    }
   }
 
 }

--- a/src/Service/BorderService.php
+++ b/src/Service/BorderService.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
 use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+use Drupal\kingly_layouts\KinglyLayoutsValidationTrait;
 
 /**
  * Service to manage border options for Kingly Layouts.
@@ -19,6 +20,7 @@ class BorderService implements KinglyLayoutsDisplayOptionInterface {
 
   use StringTranslationTrait;
   use KinglyLayoutsUtilityTrait;
+  use KinglyLayoutsValidationTrait;
 
   /**
    * The current user.
@@ -229,24 +231,6 @@ class BorderService implements KinglyLayoutsDisplayOptionInterface {
       return TRUE;
     }
     return FALSE;
-  }
-
-  /**
-   * Validates a color hex code form element.
-   *
-   * @param array $element
-   *   The form element to validate.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
-   */
-  public function validateColorHex(array &$element, FormStateInterface $form_state): void {
-    $value = $element['#value'];
-    // Check if a value is provided and if it matches the hex color pattern.
-    // The pattern ensures it starts with '#' and is followed by exactly 6 hex
-    // characters.
-    if (!empty($value) && !preg_match('/^#([a-fA-F0-9]{6})$/', $value)) {
-      $form_state->setError($element, $this->t('The color must be a valid 6-digit hex code starting with # (e.g., #RRGGBB).'));
-    }
   }
 
 }

--- a/src/Service/ColorService.php
+++ b/src/Service/ColorService.php
@@ -7,6 +7,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+use Drupal\kingly_layouts\KinglyLayoutsValidationTrait;
 
 /**
  * Service to manage color options for Kingly Layouts.
@@ -16,6 +17,7 @@ use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
 class ColorService implements KinglyLayoutsDisplayOptionInterface {
 
   use StringTranslationTrait;
+  use KinglyLayoutsValidationTrait;
 
   /**
    * The current user.
@@ -33,6 +35,15 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
   public function __construct(AccountInterface $current_user, TranslationInterface $string_translation) {
     $this->currentUser = $current_user;
     $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    return [
+      'foreground_color' => '',
+    ];
   }
 
   /**
@@ -79,33 +90,6 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
     // Validate if the stored color is a valid hex code before applying.
     if (!empty($foreground_color) && preg_match('/^#([a-fA-F0-9]{6})$/', $foreground_color)) {
       $build['#attributes']['style'][] = 'color: ' . $foreground_color . ';';
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultConfiguration(): array {
-    return [
-      'foreground_color' => '',
-    ];
-  }
-
-  /**
-   * Validates a color hex code form element.
-   *
-   * @param array $element
-   *   The form element to validate.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
-   */
-  public function validateColorHex(array &$element, FormStateInterface $form_state): void {
-    $value = $element['#value'];
-    // Check if a value is provided and if it matches the hex color pattern.
-    // The pattern ensures it starts with '#' and is followed by exactly 6 hex
-    // characters.
-    if (!empty($value) && !preg_match('/^#([a-fA-F0-9]{6})$/', $value)) {
-      $form_state->setError($element, $this->t('The color must be a valid 6-digit hex code starting with # (e.g., #RRGGBB).'));
     }
   }
 


### PR DESCRIPTION
Created a new `KinglyLayoutsValidationTrait` to house the `validateColorHex` method. This trait is now used by the ColorService, BorderService, and BackgroundService.

This change removes duplicated code from three different services, improving maintainability and ensuring consistent validation behavior for all color input fields.