### PR TITLE
refactor(color): Unify color inputs to use core picker with explicit …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
   ],
   "license": "GPL-2.0-or-later",
   "require": {
-    "drupal/core": "^10.3 || ^11",
-    "drupal/color_field": "^3.0"
+    "drupal/core": "^10.3 || ^11"
   }
 }

--- a/kingly_layouts.info.yml
+++ b/kingly_layouts.info.yml
@@ -5,4 +5,3 @@ package: Custom
 core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:layout_discovery
-  - drupal:color_field

--- a/src/Service/DisplayOption/ColorService.php
+++ b/src/Service/DisplayOption/ColorService.php
@@ -49,7 +49,7 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
    */
   public static function defaultConfiguration(): array {
     return [
-      'foreground_color' => '#FFFFFF',
+      'foreground_color' => '',
     ];
   }
 
@@ -65,17 +65,27 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
       '#access' => $this->currentUser->hasPermission('administer kingly layouts colors'),
     ];
 
+    // Use an "enable" checkbox to control whether a color is set.
+    $form[$form_key]['foreground_color_enable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Set a foreground color'),
+      // The checkbox is ticked if a color value is already saved.
+      '#default_value' => !empty($configuration['foreground_color']),
+    ];
+
     $form[$form_key]['foreground_color'] = [
       '#type' => 'color',
       '#title' => $this->t('Foreground Color'),
-      '#default_value' => $configuration['foreground_color'],
+      // Set a default to prevent saving 'black' if enabled but untouched.
+      '#default_value' => $configuration['foreground_color'] ?: '#ffffff',
       '#description' => $this->t('Select the text color for this section. Enter a hex code (e.g., #FFFFFF).'),
-      '#attributes' => [
-        'type' => 'color',
-      ],
-      '#pattern' => '#[0-9a-fA-F]{6}',
-      // Add server-side validation for the hex color format.
       '#element_validate' => [[$this, 'validateColorHex']],
+      // The color picker is only visible if the 'enable' checkbox is ticked.
+      '#states' => [
+        'visible' => [
+          ':input[name="layout_settings[' . $form_key . '][foreground_color_enable]"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     return $form;
@@ -87,8 +97,16 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
   public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
     $form_key = $this->getFormKey();
     $values = $form_state->getValue($form_key, []);
-    // Ensure the hex code is stored, or an empty string if not provided.
-    $configuration['foreground_color'] = $values['foreground_color'] ?? '';
+
+    // Check the 'enable' checkbox to decide what to save.
+    if (!empty($values['foreground_color_enable'])) {
+      // If enabled, save the color value.
+      $configuration['foreground_color'] = $values['foreground_color'] ?? '';
+    }
+    else {
+      // If not enabled, save an empty string to signify "no color".
+      $configuration['foreground_color'] = '';
+    }
   }
 
   /**
@@ -96,7 +114,7 @@ class ColorService implements KinglyLayoutsDisplayOptionInterface {
    */
   public function processBuild(array &$build, array $configuration): void {
     $foreground_color = $configuration['foreground_color'];
-    // Validate if the stored color is a valid hex code before applying.
+    // This check now correctly handles an empty string for "no color".
     if (!empty($foreground_color) && preg_match('/^#([a-fA-F0-9]{6})$/', $foreground_color)) {
       $build['#attributes']['style'][] = 'color: ' . $foreground_color . ';';
     }


### PR DESCRIPTION
…controls

Removes the dependency on the `color_field` module and standardizes all color selection fields (foreground, border, background, gradient, overlay) to use the core Form API 'color' element.

This change addresses two key issues:
1. Simplifies module dependencies by removing `color_field`.
2. Corrects a UX flaw where clearing a color input would cause it to be saved as black (#000000) due to browser default behavior.

The new implementation provides a clear and unambiguous user experience:
- Optional colors (foreground, border, overlay) are paired with an "Enable" checkbox.
- The background color option is handled by adding a "None" choice to the main "Background Type" radio buttons.

This ensures that colors are only applied when explicitly chosen by the user and provides a clear path for them to unset a previously selected color.