### PR TITLE
feat(display_options): Implement responsive field system

### DIFF
--- a/css/_variables.css
+++ b/css/_variables.css
@@ -27,7 +27,10 @@
   --kl-border-width-sm: 1px;
   --kl-border-width-md: 2px;
   --kl-border-width-lg: 4px;
-  /* Breakpoints (adjust to match your theme's actual breakpoints) */
+  /* Breakpoints (match BreakpointService.php) */
+  --kl-breakpoint-md: 768px;
+  --kl-breakpoint-lg: 1024px;
+  /* Old Breakpoints (for backward compatibility if needed, will be phased out) */
   --kl-breakpoint-mobile-max: 767px;
   --kl-breakpoint-tablet-min: 768px;
   --kl-breakpoint-tablet-max: 1023px;

--- a/css/responsiveness.css
+++ b/css/responsiveness.css
@@ -6,23 +6,24 @@
 /* --- Responsiveness Utilities --- */
 
 /* Hide on Breakpoint */
-/* Using common breakpoints, adjust as per theme's actual breakpoints */
-@media (max-width: var(--kl-breakpoint-mobile-max)) {
-  /* Mobile */
+/* Uses the new breakpoint variables for consistency. */
+
+/* Mobile (Up to tablet breakpoint) */
+@media (max-width: calc(var(--kl-breakpoint-tablet) - 1px)) {
   .kl-hide-on-mobile {
     display: none !important;
   }
 }
 
-@media (min-width: var(--kl-breakpoint-tablet-min)) and (max-width: var(--kl-breakpoint-tablet-max)) {
-  /* Tablet */
+/* Tablet (Between tablet and desktop breakpoints) */
+@media (min-width: var(--kl-breakpoint-tablet)) and (max-width: calc(var(--kl-breakpoint-desktop) - 1px)) {
   .kl-hide-on-tablet {
     display: none !important;
   }
 }
 
-@media (min-width: var(--kl-breakpoint-desktop-min)) {
-  /* Desktop */
+/* Desktop (From desktop breakpoint and up) */
+@media (min-width: var(--kl-breakpoint-desktop)) {
   .kl-hide-on-desktop {
     display: none !important;
   }

--- a/css/spacing.css
+++ b/css/spacing.css
@@ -1,16 +1,12 @@
 /*
 * @file
-* Provides spacing utility styles for Kingly Layouts.
+* Provides responsive spacing utility styles for Kingly Layouts.
 */
 
-/* --- Spacing Utilities (Padding & Margin) --- */
+/* --- Base Spacing Utilities (Mobile First) --- */
+/* These apply from the smallest screen size up. */
 
-/*
-* Padding X
-* These utilities now ONLY set the --kl-padding-x-additional variable.
-* This variable is then consumed by the container type rules above to apply
-* the final padding value correctly, avoiding specificity conflicts.
-*/
+/* Padding X */
 .kl-padding-x-xs {
   --kl-padding-x-additional: var(--kl-spacing-xs);
 }
@@ -49,7 +45,7 @@
   padding-bottom: var(--kl-spacing-xl);
 }
 
-/* Gap (for flex/grid containers) */
+/* Gap */
 .kl-gap-xs {
   gap: var(--kl-spacing-xs);
 }
@@ -108,4 +104,212 @@
 .kl-margin-y-xl {
   margin-top: var(--kl-spacing-xl);
   margin-bottom: var(--kl-spacing-xl);
+}
+
+
+/* --- Medium (md) Breakpoint Overrides --- */
+@media (min-width: 768px) {
+  /* Padding X */
+  .md--kl-padding-x-xs {
+    --kl-padding-x-additional: var(--kl-spacing-xs);
+}
+  .md--kl-padding-x-sm {
+    --kl-padding-x-additional: var(--kl-spacing-sm);
+}
+  .md--kl-padding-x-md {
+    --kl-padding-x-additional: var(--kl-spacing-md);
+}
+  .md--kl-padding-x-lg {
+    --kl-padding-x-additional: var(--kl-spacing-lg);
+}
+  .md--kl-padding-x-xl {
+    --kl-padding-x-additional: var(--kl-spacing-xl);
+}
+
+  /* Padding Y */
+  .md--kl-padding-y-xs {
+    padding-top: var(--kl-spacing-xs);
+    padding-bottom: var(--kl-spacing-xs);
+}
+  .md--kl-padding-y-sm {
+    padding-top: var(--kl-spacing-sm);
+    padding-bottom: var(--kl-spacing-sm);
+}
+  .md--kl-padding-y-md {
+    padding-top: var(--kl-spacing-md);
+    padding-bottom: var(--kl-spacing-md);
+}
+  .md--kl-padding-y-lg {
+    padding-top: var(--kl-spacing-lg);
+    padding-bottom: var(--kl-spacing-lg);
+}
+  .md--kl-padding-y-xl {
+    padding-top: var(--kl-spacing-xl);
+    padding-bottom: var(--kl-spacing-xl);
+}
+
+  /* Gap */
+  .md--kl-gap-xs {
+    gap: var(--kl-spacing-xs);
+}
+  .md--kl-gap-sm {
+    gap: var(--kl-spacing-sm);
+}
+  .md--kl-gap-md {
+    gap: var(--kl-spacing-md);
+}
+  .md--kl-gap-lg {
+    gap: var(--kl-spacing-lg);
+}
+  .md--kl-gap-xl {
+    gap: var(--kl-spacing-xl);
+}
+
+  /* Margin X */
+  .md--kl-margin-x-xs {
+    margin-left: var(--kl-spacing-xs);
+    margin-right: var(--kl-spacing-xs);
+}
+  .md--kl-margin-x-sm {
+    margin-left: var(--kl-spacing-sm);
+    margin-right: var(--kl-spacing-sm);
+}
+  .md--kl-margin-x-md {
+    margin-left: var(--kl-spacing-md);
+    margin-right: var(--kl-spacing-md);
+}
+  .md--kl-margin-x-lg {
+    margin-left: var(--kl-spacing-lg);
+    margin-right: var(--kl-spacing-lg);
+}
+  .md--kl-margin-x-xl {
+    margin-left: var(--kl-spacing-xl);
+    margin-right: var(--kl-spacing-xl);
+}
+
+  /* Margin Y */
+  .md--kl-margin-y-xs {
+    margin-top: var(--kl-spacing-xs);
+    margin-bottom: var(--kl-spacing-xs);
+}
+  .md--kl-margin-y-sm {
+    margin-top: var(--kl-spacing-sm);
+    margin-bottom: var(--kl-spacing-sm);
+}
+  .md--kl-margin-y-md {
+    margin-top: var(--kl-spacing-md);
+    margin-bottom: var(--kl-spacing-md);
+}
+  .md--kl-margin-y-lg {
+    margin-top: var(--kl-spacing-lg);
+    margin-bottom: var(--kl-spacing-lg);
+}
+  .md--kl-margin-y-xl {
+    margin-top: var(--kl-spacing-xl);
+    margin-bottom: var(--kl-spacing-xl);
+}
+}
+
+
+/* --- Large (lg) Breakpoint Overrides --- */
+@media (min-width: 1024px) {
+  /* Padding X */
+  .lg--kl-padding-x-xs {
+    --kl-padding-x-additional: var(--kl-spacing-xs);
+}
+  .lg--kl-padding-x-sm {
+    --kl-padding-x-additional: var(--kl-spacing-sm);
+}
+  .lg--kl-padding-x-md {
+    --kl-padding-x-additional: var(--kl-spacing-md);
+}
+  .lg--kl-padding-x-lg {
+    --kl-padding-x-additional: var(--kl-spacing-lg);
+}
+  .lg--kl-padding-x-xl {
+    --kl-padding-x-additional: var(--kl-spacing-xl);
+}
+
+  /* Padding Y */
+  .lg--kl-padding-y-xs {
+    padding-top: var(--kl-spacing-xs);
+    padding-bottom: var(--kl-spacing-xs);
+}
+  .lg--kl-padding-y-sm {
+    padding-top: var(--kl-spacing-sm);
+    padding-bottom: var(--kl-spacing-sm);
+}
+  .lg--kl-padding-y-md {
+    padding-top: var(--kl-spacing-md);
+    padding-bottom: var(--kl-spacing-md);
+}
+  .lg--kl-padding-y-lg {
+    padding-top: var(--kl-spacing-lg);
+    padding-bottom: var(--kl-spacing-lg);
+}
+  .lg--kl-padding-y-xl {
+    padding-top: var(--kl-spacing-xl);
+    padding-bottom: var(--kl-spacing-xl);
+}
+
+  /* Gap */
+  .lg--kl-gap-xs {
+    gap: var(--kl-spacing-xs);
+}
+  .lg--kl-gap-sm {
+    gap: var(--kl-spacing-sm);
+}
+  .lg--kl-gap-md {
+    gap: var(--kl-spacing-md);
+}
+  .lg--kl-gap-lg {
+    gap: var(--kl-spacing-lg);
+}
+  .lg--kl-gap-xl {
+    gap: var(--kl-spacing-xl);
+}
+
+  /* Margin X */
+  .lg--kl-margin-x-xs {
+    margin-left: var(--kl-spacing-xs);
+    margin-right: var(--kl-spacing-xs);
+}
+  .lg--kl-margin-x-sm {
+    margin-left: var(--kl-spacing-sm);
+    margin-right: var(--kl-spacing-sm);
+}
+  .lg--kl-margin-x-md {
+    margin-left: var(--kl-spacing-md);
+    margin-right: var(--kl-spacing-md);
+}
+  .lg--kl-margin-x-lg {
+    margin-left: var(--kl-spacing-lg);
+    margin-right: var(--kl-spacing-lg);
+}
+  .lg--kl-margin-x-xl {
+    margin-left: var(--kl-spacing-xl);
+    margin-right: var(--kl-spacing-xl);
+}
+
+  /* Margin Y */
+  .lg--kl-margin-y-xs {
+    margin-top: var(--kl-spacing-xs);
+    margin-bottom: var(--kl-spacing-xs);
+}
+  .lg--kl-margin-y-sm {
+    margin-top: var(--kl-spacing-sm);
+    margin-bottom: var(--kl-spacing-sm);
+}
+  .lg--kl-margin-y-md {
+    margin-top: var(--kl-spacing-md);
+    margin-bottom: var(--kl-spacing-md);
+}
+  .lg--kl-margin-y-lg {
+    margin-top: var(--kl-spacing-lg);
+    margin-bottom: var(--kl-spacing-lg);
+}
+  .lg--kl-margin-y-xl {
+    margin-top: var(--kl-spacing-xl);
+    margin-bottom: var(--kl-spacing-xl);
+}
 }

--- a/kingly_layouts.services.yml
+++ b/kingly_layouts.services.yml
@@ -4,6 +4,14 @@ services:
     arguments:
       - !tagged_iterator kingly_layouts.display_option
 
+  kingly_layouts.breakpoint_service:
+    class: Drupal\kingly_layouts\Service\BreakpointService
+    arguments: ['@string_translation']
+
+  kingly_layouts.responsive_field_service:
+    class: Drupal\kingly_layouts\Service\ResponsiveFieldService
+    arguments: ['@kingly_layouts.breakpoint_service']
+
   kingly_layouts.alignment_service:
     class: Drupal\kingly_layouts\Service\DisplayOption\AlignmentService
     arguments: [ '@current_user', '@string_translation' ]
@@ -66,7 +74,7 @@ services:
 
   kingly_layouts.spacing_service:
     class: Drupal\kingly_layouts\Service\DisplayOption\SpacingService
-    arguments: [ '@current_user', '@string_translation' ]
+    arguments: [ '@current_user', '@string_translation', '@kingly_layouts.responsive_field_service' ]
     tags:
       - { name: kingly_layouts.display_option, priority: 10 }
 

--- a/src/Service/BreakpointService.php
+++ b/src/Service/BreakpointService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+/**
+ * Provides a centralized definition of responsive breakpoints.
+ *
+ * This service defines the breakpoints used across Kingly Layouts for
+ * responsive design controls. It ensures consistency and makes it easy to
+ * manage breakpoints from a single location.
+ */
+class BreakpointService {
+
+  use StringTranslationTrait;
+
+  /**
+   * An array of breakpoint definitions.
+   *
+   * @var array
+   */
+  protected array $breakpoints;
+
+  /**
+   * Constructs a BreakpointService object.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(TranslationInterface $string_translation) {
+    $this->stringTranslation = $string_translation;
+    $this->initializeBreakpoints();
+  }
+
+  /**
+   * Initializes the breakpoint definitions.
+   *
+   * This method defines the standard breakpoints used in the system. Each
+   * breakpoint includes a machine name, a human-readable label, and a CSS
+   * class prefix.
+   */
+  protected function initializeBreakpoints(): void {
+    // Defines the breakpoints in a mobile-first order.
+    // 'mobile' is the base and has no prefix.
+    $this->breakpoints = [
+      'mobile' => [
+        'id' => 'mobile',
+        'label' => $this->t('Mobile (Default)'),
+        'prefix' => '',
+      ],
+      'md' => [
+        'id' => 'md',
+        'label' => $this->t('Medium (md)'),
+        // Use a double-hyphen as a safe, standard separator.
+        'prefix' => 'md--',
+      ],
+      'lg' => [
+        'id' => 'lg',
+        'label' => $this->t('Large (lg)'),
+        // Use a double-hyphen as a safe, standard separator.
+        'prefix' => 'lg--',
+      ],
+    ];
+  }
+
+  /**
+   * Gets all defined breakpoints.
+   *
+   * @return array
+   *   An associative array of breakpoint definitions, keyed by breakpoint ID.
+   */
+  public function getBreakpoints(): array {
+    return $this->breakpoints;
+  }
+
+}

--- a/src/Service/DisplayOption/SpacingService.php
+++ b/src/Service/DisplayOption/SpacingService.php
@@ -8,9 +8,13 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
 use Drupal\kingly_layouts\KinglyLayoutsUtilityTrait;
+use Drupal\kingly_layouts\Service\ResponsiveFieldService;
 
 /**
  * Service to manage spacing options for Kingly Layouts.
+ *
+ * This service now uses the ResponsiveFieldService to provide spacing controls
+ * for different breakpoints.
  */
 class SpacingService implements KinglyLayoutsDisplayOptionInterface {
 
@@ -25,16 +29,26 @@ class SpacingService implements KinglyLayoutsDisplayOptionInterface {
   protected AccountInterface $currentUser;
 
   /**
+   * The responsive field service.
+   *
+   * @var \Drupal\kingly_layouts\Service\ResponsiveFieldService
+   */
+  protected ResponsiveFieldService $responsiveFieldService;
+
+  /**
    * Constructs a new SpacingService object.
    *
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   The current user.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation service.
+   * @param \Drupal\kingly_layouts\Service\ResponsiveFieldService $responsive_field_service
+   *   The service for creating responsive fields.
    */
-  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation) {
+  public function __construct(AccountInterface $current_user, TranslationInterface $string_translation, ResponsiveFieldService $responsive_field_service) {
     $this->currentUser = $current_user;
     $this->stringTranslation = $string_translation;
+    $this->responsiveFieldService = $responsive_field_service;
   }
 
   /**
@@ -56,47 +70,93 @@ class SpacingService implements KinglyLayoutsDisplayOptionInterface {
       '#access' => $this->currentUser->hasPermission('administer kingly layouts spacing'),
     ];
 
-    $form[$form_key]['horizontal_padding_option'] = [
+    // Define base fields for reuse.
+    $padding_h_base = [
       '#type' => 'select',
       '#title' => $this->t('Horizontal Padding'),
       '#options' => $this->getScaleOptions(),
-      '#default_value' => $configuration['horizontal_padding_option'],
-      '#description' => $this->t('Select the horizontal padding for the layout. For "Full Width (Background Only)" layouts, this padding is added to the default content alignment. For "Edge to Edge" layouts, this padding is applied from the viewport edge.'),
+      '#description' => $this->t('Select padding for different breakpoints.'),
     ];
-
-    $form[$form_key]['vertical_padding_option'] = [
+    $padding_v_base = [
       '#type' => 'select',
       '#title' => $this->t('Vertical Padding'),
       '#options' => $this->getScaleOptions(),
-      '#default_value' => $configuration['vertical_padding_option'],
-      '#description' => $this->t('Select the desired vertical padding (top and bottom) for the layout container.'),
+      '#description' => $this->t('Select padding for different breakpoints.'),
     ];
-
-    $form[$form_key]['gap_option'] = [
+    $gap_base = [
       '#type' => 'select',
       '#title' => $this->t('Gap'),
       '#options' => $this->getScaleOptions(),
-      '#default_value' => $configuration['gap_option'],
-      '#description' => $this->t('Select the desired gap between layout columns/regions.'),
+      '#description' => $this->t('Select gap for different breakpoints.'),
     ];
-
-    $form[$form_key]['horizontal_margin_option'] = [
+    $margin_h_base = [
       '#type' => 'select',
       '#title' => $this->t('Horizontal Margin'),
       '#options' => $this->getScaleOptions(),
-      '#default_value' => $configuration['horizontal_margin_option'],
-      '#description' => $this->t('Select the horizontal margin for the layout. This margin will not be applied if "Full Width" or "Edge to Edge" is selected.'),
+      '#description' => $this->t('Select margin for different breakpoints.'),
     ];
-
-    $form[$form_key]['vertical_margin_option'] = [
+    $margin_v_base = [
       '#type' => 'select',
       '#title' => $this->t('Vertical Margin'),
       '#options' => $this->getScaleOptions(),
-      '#default_value' => $configuration['vertical_margin_option'],
-      '#description' => $this->t('Select the desired vertical margin (top and bottom) for the layout container.'),
+      '#description' => $this->t('Select margin for different breakpoints.'),
     ];
 
+    // Build responsive fields using the service.
+    $form[$form_key]['horizontal_padding_option'] = $this->responsiveFieldService->buildResponsiveFields('horizontal_padding_option', $padding_h_base, $configuration);
+    $form[$form_key]['vertical_padding_option'] = $this->responsiveFieldService->buildResponsiveFields('vertical_padding_option', $padding_v_base, $configuration);
+    $form[$form_key]['gap_option'] = $this->responsiveFieldService->buildResponsiveFields('gap_option', $gap_base, $configuration);
+    $form[$form_key]['horizontal_margin_option'] = $this->responsiveFieldService->buildResponsiveFields('horizontal_margin_option', $margin_h_base, $configuration);
+    $form[$form_key]['vertical_margin_option'] = $this->responsiveFieldService->buildResponsiveFields('vertical_margin_option', $margin_v_base, $configuration);
+
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
+    $form_key = $this->getFormKey();
+    $spacing_values = $form_state->getValue($form_key, []);
+
+    // Let the responsive service handle the submission for each field.
+    $this->responsiveFieldService->submitResponsiveFields($form_state, $configuration, 'horizontal_padding_option', $spacing_values['horizontal_padding_option']);
+    $this->responsiveFieldService->submitResponsiveFields($form_state, $configuration, 'vertical_padding_option', $spacing_values['vertical_padding_option']);
+    $this->responsiveFieldService->submitResponsiveFields($form_state, $configuration, 'gap_option', $spacing_values['gap_option']);
+    $this->responsiveFieldService->submitResponsiveFields($form_state, $configuration, 'horizontal_margin_option', $spacing_values['horizontal_margin_option']);
+    $this->responsiveFieldService->submitResponsiveFields($form_state, $configuration, 'vertical_margin_option', $spacing_values['vertical_margin_option']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultConfiguration(): array {
+    // The configuration is now nested for responsiveness.
+    return [
+      'horizontal_padding_option' => [],
+      'vertical_padding_option' => [],
+      'gap_option' => [],
+      'horizontal_margin_option' => [],
+      'vertical_margin_option' => [],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processBuild(array &$build, array $configuration): void {
+    $has_spacing = FALSE;
+
+    // Use the responsive service to process classes for each property.
+    $has_spacing = $this->responsiveFieldService->processResponsiveClasses($build, $configuration, 'horizontal_padding_option', 'kl-padding-x-') || $has_spacing;
+    $has_spacing = $this->responsiveFieldService->processResponsiveClasses($build, $configuration, 'vertical_padding_option', 'kl-padding-y-') || $has_spacing;
+    $has_spacing = $this->responsiveFieldService->processResponsiveClasses($build, $configuration, 'gap_option', 'kl-gap-') || $has_spacing;
+    $has_spacing = $this->responsiveFieldService->processResponsiveClasses($build, $configuration, 'horizontal_margin_option', 'kl-margin-x-') || $has_spacing;
+    $has_spacing = $this->responsiveFieldService->processResponsiveClasses($build, $configuration, 'vertical_margin_option', 'kl-margin-y-') || $has_spacing;
+
+    if ($has_spacing) {
+      $build['#attached']['library'][] = 'kingly_layouts/spacing';
+    }
   }
 
   /**
@@ -114,142 +174,6 @@ class SpacingService implements KinglyLayoutsDisplayOptionInterface {
       'lg' => $this->t('Large (2rem)'),
       'xl' => $this->t('Extra Large (4rem)'),
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function submitConfigurationForm(array $form, FormStateInterface $form_state, array &$configuration): void {
-    $form_key = $this->getFormKey();
-    $spacing_values = $form_state->getValue($form_key, []);
-    foreach ([
-      'horizontal_padding_option',
-      'vertical_padding_option',
-      'gap_option',
-      'horizontal_margin_option',
-      'vertical_margin_option',
-    ] as $key) {
-      $configuration[$key] = $spacing_values[$key] ?? self::defaultConfiguration()[$key];
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultConfiguration(): array {
-    return [
-      'horizontal_padding_option' => self::NONE_OPTION_KEY,
-      'vertical_padding_option' => self::NONE_OPTION_KEY,
-      'gap_option' => self::NONE_OPTION_KEY,
-      'horizontal_margin_option' => self::NONE_OPTION_KEY,
-      'vertical_margin_option' => self::NONE_OPTION_KEY,
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function processBuild(array &$build, array $configuration): void {
-    $has_spacing = $this->determineLibraryAttachment($configuration);
-
-    // Apply spacing utility classes.
-    $this->applyPaddingClasses($build, $configuration);
-    $this->applyGapClass($build, $configuration);
-    $this->applyMarginClasses($build, $configuration);
-
-    if ($has_spacing) {
-      $build['#attached']['library'][] = 'kingly_layouts/spacing';
-    }
-  }
-
-  /**
-   * Determines if the spacing library should be attached.
-   *
-   * Checks if any non-default spacing options are set.
-   *
-   * @param array $configuration
-   *   The layout's current configuration.
-   *
-   * @return bool
-   *   TRUE if the spacing library should be attached, FALSE otherwise.
-   */
-  private function determineLibraryAttachment(array $configuration): bool {
-    $defaults = self::defaultConfiguration();
-    $spacing_options_keys = [
-      'horizontal_padding_option',
-      'vertical_padding_option',
-      'gap_option',
-      'horizontal_margin_option',
-      'vertical_margin_option',
-    ];
-
-    foreach ($spacing_options_keys as $option_key) {
-      if (($configuration[$option_key] ?? $defaults[$option_key]) !== $defaults[$option_key]) {
-        return TRUE;
-      }
-    }
-    return FALSE;
-  }
-
-  /**
-   * Applies padding-related CSS classes to the build array.
-   *
-   * @param array &$build
-   *   The render array, passed by reference.
-   * @param array $configuration
-   *   The layout's current configuration.
-   */
-  private function applyPaddingClasses(array &$build, array $configuration): void {
-    // Determine effective horizontal padding based on container type.
-    $container_type = $configuration['container_type'];
-    $h_padding_effective = $configuration['horizontal_padding_option'];
-
-    // For 'full' and 'edge-to-edge' container types, the horizontal padding
-    // is handled differently by CSS. The `kl-padding-x-` class
-    // sets a CSS variable, which the container CSS then consumes.
-    // 'hero' also handles horizontal padding differently.
-    $this->applyClassFromConfig($build, 'kl-padding-x-', $h_padding_effective, $configuration);
-    $this->applyClassFromConfig($build, 'kl-padding-y-', 'vertical_padding_option', $configuration);
-  }
-
-  /**
-   * Applies gap-related CSS classes to the build array.
-   *
-   * @param array &$build
-   *   The render array, passed by reference.
-   * @param array $configuration
-   *   The layout's current configuration.
-   */
-  private function applyGapClass(array &$build, array $configuration): void {
-    $this->applyClassFromConfig($build, 'kl-gap-', 'gap_option', $configuration);
-  }
-
-  /**
-   * Applies margin-related CSS classes to the build array.
-   *
-   * @param array &$build
-   *   The render array, passed by reference.
-   * @param array $configuration
-   *   The layout's current configuration.
-   */
-  private function applyMarginClasses(array &$build, array $configuration): void {
-    $container_type = $configuration['container_type'];
-    $apply_horizontal_margin = TRUE;
-
-    // Horizontal margins are typically not applied to full-width or hero
-    // layouts.
-    switch ($container_type) {
-      case 'full':
-      case 'edge-to-edge':
-      case 'hero':
-        $apply_horizontal_margin = FALSE;
-        break;
-    }
-
-    if ($apply_horizontal_margin) {
-      $this->applyClassFromConfig($build, 'kl-margin-x-', 'horizontal_margin_option', $configuration);
-    }
-    $this->applyClassFromConfig($build, 'kl-margin-y-', 'vertical_margin_option', $configuration);
   }
 
 }

--- a/src/Service/ResponsiveFieldService.php
+++ b/src/Service/ResponsiveFieldService.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Drupal\kingly_layouts\Service;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\kingly_layouts\KinglyLayoutsDisplayOptionInterface;
+
+/**
+ * Service to generate and process responsive form fields for display options.
+ *
+ * This service allows other display option services (like SpacingService) to
+ * easily create form fields that are configurable per breakpoint. It handles
+ * the form generation, submission, and CSS class processing logic.
+ */
+class ResponsiveFieldService {
+
+  use StringTranslationTrait;
+
+  /**
+   * The breakpoint service.
+   *
+   * @var \Drupal\kingly_layouts\Service\BreakpointService
+   */
+  protected BreakpointService $breakpointService;
+
+  /**
+   * Constructs a new ResponsiveFieldService object.
+   *
+   * @param \Drupal\kingly_layouts\Service\BreakpointService $breakpoint_service
+   *   The breakpoint service.
+   */
+  public function __construct(BreakpointService $breakpoint_service) {
+    $this->breakpointService = $breakpoint_service;
+  }
+
+  /**
+   * Builds a set of responsive fields for a given configuration key.
+   *
+   * @param string $config_key
+   *   The base configuration key (e.g., 'horizontal_padding_option').
+   * @param array $base_field
+   *   The base Form API element definition (e.g., a select list).
+   * @param array $configuration
+   *   The layout's current configuration.
+   *
+   * @return array
+   *   A Form API array containing the set of fields for each breakpoint.
+   */
+  public function buildResponsiveFields(string $config_key, array $base_field, array $configuration): array {
+    $fields_container = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['kl-responsive-fields']],
+    ];
+
+    $breakpoints = $this->breakpointService->getBreakpoints();
+    foreach ($breakpoints as $id => $breakpoint) {
+      // Each field gets a unique key based on the breakpoint ID.
+      $field_key = $config_key . '__' . $id;
+
+      $fields_container[$field_key] = $base_field;
+      // Modify the title for each breakpoint field for clarity.
+      $fields_container[$field_key]['#title'] = $breakpoint['label'];
+
+      // Fetch the default value from the nested configuration structure.
+      $default_value = $configuration[$config_key][$id] ?? KinglyLayoutsDisplayOptionInterface::NONE_OPTION_KEY;
+      $fields_container[$field_key]['#default_value'] = $default_value;
+
+      // Remove description from subsequent fields to avoid repetition.
+      if ($id !== 'mobile') {
+        unset($fields_container[$field_key]['#description']);
+      }
+    }
+
+    // Wrap the container in a fieldset to group them visually.
+    return [
+      '#type' => 'fieldset',
+      '#title' => $base_field['#title'],
+      '#description' => $base_field['#description'] ?? NULL,
+      'fields' => $fields_container,
+    ];
+  }
+
+  /**
+   * Handles form submission for a set of responsive fields.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   * @param array &$configuration
+   *   The layout's configuration array, passed by reference.
+   * @param string $config_key
+   *   The base configuration key (e.g., 'horizontal_padding_option').
+   * @param array $form_values
+   *   The submitted values for the parent form group (e.g., 'spacing').
+   */
+  public function submitResponsiveFields(FormStateInterface $form_state, array &$configuration, string $config_key, array $form_values): void {
+    $breakpoints = $this->breakpointService->getBreakpoints();
+    $responsive_values = [];
+
+    foreach ($breakpoints as $id => $breakpoint) {
+      $field_key = $config_key . '__' . $id;
+      if (isset($form_values['fields'][$field_key])) {
+        $responsive_values[$id] = $form_values['fields'][$field_key];
+      }
+    }
+
+    // Store the values in a nested array under the main config key.
+    $configuration[$config_key] = $responsive_values;
+  }
+
+  /**
+   * Processes responsive configuration to generate CSS classes.
+   *
+   * @param array &$build
+   *   The render array for the layout, passed by reference.
+   * @param array $configuration
+   *   The layout's current configuration.
+   * @param string $config_key
+   *   The base configuration key (e.g., 'horizontal_padding_option').
+   * @param string $class_prefix
+   *   The CSS class prefix (e.g., 'kl-padding-x-').
+   *
+   * @return bool
+   *   TRUE if any classes were added, FALSE otherwise.
+   */
+  public function processResponsiveClasses(array &$build, array $configuration, string $config_key, string $class_prefix): bool {
+    $has_classes = FALSE;
+    if (empty($configuration[$config_key]) || !is_array($configuration[$config_key])) {
+      return FALSE;
+    }
+
+    $breakpoints = $this->breakpointService->getBreakpoints();
+    $values = $configuration[$config_key];
+
+    foreach ($breakpoints as $id => $breakpoint) {
+      $value = $values[$id] ?? NULL;
+
+      // Ensure we have a value and it's not the 'None' option.
+      $none_key = KinglyLayoutsDisplayOptionInterface::NONE_OPTION_KEY;
+      if (!empty($value) && $value !== $none_key) {
+        $class = $breakpoint['prefix'] . $class_prefix . $value;
+        $build['#attributes']['class'][] = $class;
+        $has_classes = TRUE;
+      }
+    }
+    return $has_classes;
+  }
+
+}


### PR DESCRIPTION
Introduces a centralized system for creating responsive display options.

- Adds BreakpointService to define standard responsive breakpoints (md, lg).
- Adds ResponsiveFieldService to build, submit, and process form fields that are configurable per breakpoint.
- Refactors SpacingService to use the new responsive system for padding, margin, and gap, allowing different values for each breakpoint.
- Updates CSS to use breakpoint variables and support responsive utility classes with a robust double-hyphen prefix (e.g., `md--kl-padding-x-md`).