### PR TITLE
feat(responsiveness): Integrate ResponsiveFieldService for visibility…

### DIFF
--- a/css/responsiveness.css
+++ b/css/responsiveness.css
@@ -1,30 +1,36 @@
 /*
-* @file
-* Provides responsiveness utility styles for Kingly Layouts.
-*/
+ * @file
+ * Provides responsiveness utility styles for Kingly Layouts.
+ */
 
-/* --- Responsiveness Utilities --- */
+/* --- Hide on Breakpoint Utilities --- */
+/*
+ * These classes are applied to hide the element only on the specified
+ * breakpoint ranges. The CSS variables are placeholders for consistency but
+ * could be replaced with static values if preferred, as breakpoints are
+ * unlikely to change frequently.
+ */
 
-/* Hide on Breakpoint */
-/* Uses the new breakpoint variables for consistency. */
-
-/* Mobile (Up to tablet breakpoint) */
-@media (max-width: calc(var(--kl-breakpoint-tablet) - 1px)) {
+/* Mobile (Up to 767px) */
+/* This covers screen widths from 0 up to the medium breakpoint. */
+@media (max-width: 767px) {
   .kl-hide-on-mobile {
     display: none !important;
   }
 }
 
-/* Tablet (Between tablet and desktop breakpoints) */
-@media (min-width: var(--kl-breakpoint-tablet)) and (max-width: calc(var(--kl-breakpoint-desktop) - 1px)) {
-  .kl-hide-on-tablet {
+/* Medium / Tablet (768px - 1023px) */
+/* This covers screen widths between the medium and large breakpoints. */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .kl-hide-on-md {
     display: none !important;
   }
 }
 
-/* Desktop (From desktop breakpoint and up) */
-@media (min-width: var(--kl-breakpoint-desktop)) {
-  .kl-hide-on-desktop {
+/* Large / Desktop (1024px and up) */
+/* This covers screen widths from the large breakpoint upwards. */
+@media (min-width: 1024px) {
+  .kl-hide-on-lg {
     display: none !important;
   }
 }

--- a/src/Service/ResponsiveFieldService.php
+++ b/src/Service/ResponsiveFieldService.php
@@ -66,10 +66,9 @@ class ResponsiveFieldService {
       $default_value = $configuration[$config_key][$id] ?? KinglyLayoutsDisplayOptionInterface::NONE_OPTION_KEY;
       $fields_container[$field_key]['#default_value'] = $default_value;
 
-      // Remove description from subsequent fields to avoid repetition.
-      if ($id !== 'mobile') {
-        unset($fields_container[$field_key]['#description']);
-      }
+      // Always remove the description from the individual field.
+      // It will be applied to the parent fieldset instead for clarity.
+      unset($fields_container[$field_key]['#description']);
     }
 
     // Wrap the container in a fieldset to group them visually.


### PR DESCRIPTION
… controls

Updates the ResponsivenessService to use the new ResponsiveFieldService, creating a consistent, per-breakpoint configuration UI.

This change replaces the previous simple "hide" logic with a more granular set of select lists, allowing users to choose between 'Visible', 'Invisible', and 'Hidden' states for each defined breakpoint (mobile, md, lg).

By leveraging the shared service, the responsiveness feature now aligns with the UI pattern established by the Spacing controls.